### PR TITLE
Added option for displaying full paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,7 @@ dependencies = [
  "bitflags",
  "clap_lex",
  "indexmap",
+ "lazy_static",
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.15.0",
@@ -1101,7 +1102,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tmux-sessionizer"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap 3.1.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmux-sessionizer"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Jared Moulton <jaredmoulton3@gmail.com>"]
 edition = "2021"
 license = "MIT"
@@ -19,7 +19,7 @@ exclude = [
 
 [dependencies]
 git2 = "0.14"
-clap = "3.1"
+clap = { version = "3.1", features = ["cargo"] }
 skim = "0.9"
 confy = "0.4"
 serde_derive = "1.0"

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ OPTIONS:
         --excluded <excluded dirs>...
             As many directory names as desired to not be searched over
 
+        --full-path <display full path>
+            Use the full path when displaying directories [posible values: true, false]
+
     -h, --help
             Print help information
 

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -12,6 +12,7 @@ pub struct Config {
     pub search_paths: Vec<String>,
     pub excluded_dirs: Vec<String>,
     pub default_session: Option<String>,
+    pub display_full_path: Option<bool>,
 }
 
 pub trait UpgradeConfig {
@@ -30,6 +31,7 @@ impl UpgradeConfig for Result<Config, confy::ConfyError> {
                     search_paths: path,
                     excluded_dirs: old_config.excluded_dirs,
                     default_session: None,
+                    display_full_path: None,
                 })
             }
         }


### PR DESCRIPTION
Hey,

Great app. 
I don't know if you a looking for contributions, but I wanted the option of showing full paths, instead of just the repository names. So I have added it as an option in the config. It is off by default.

`tms config --full-path true` to enable


I'm not sure how you handle version numbers, but i just bumped the patch.