### PR TITLE
make excluded more general

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,7 +859,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 0.7.19",
  "memchr",
  "regex-syntax",
 ]
@@ -1243,6 +1252,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 name = "tmux-sessionizer"
 version = "0.2.1"
 dependencies = [
+ "aho-corasick 1.0.1",
  "clap 4.0.19",
  "confy",
  "error-stack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde = "1.0"
 error-stack = "0.2.4"
 owo-colors = "3.5.0"
 shellexpand = "2.1.2"
+aho-corasick = "1.0.1"
 
 [[bin]]
 name = "tms"

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,14 +54,14 @@ fn main() -> Result<(), TmsError> {
     let repo_name = get_single_selection(repos.repo_string(), None)?;
     let found_repo = repos
         .find_repo(&repo_name)
-        .expect("The internal represenation of the selected repository should be present");
+        .expect("The internal representation of the selected repository should be present");
     let path = if found_repo.is_bare() {
         found_repo.path().to_string()?
     } else {
         found_repo
             .path()
             .parent()
-            .expect("bare repositores should all have parent directories")
+            .expect("bare repositories should all have parent directories")
             .to_string()?
     };
     let repo_short_name = std::path::PathBuf::from(&repo_name)
@@ -150,7 +150,7 @@ pub(crate) fn set_up_tmux_env(repo: &Repository, repo_name: &str) -> Result<(), 
         // Kill that first extra window
         execute_tmux_command(&format!("tmux kill-window -t {repo_name}:1"));
     } else {
-        // Extra stuff?? I removed launcing python environments here but that could be exposed in the configuration
+        // Extra stuff?? I removed launching python environments here but that could be exposed in the configuration
     }
     Ok(())
 }


### PR DESCRIPTION
I have `search_paths = ['~']`. (The wisdom of this choice is questionable, but here we are.) When I run `tms config --excluded ~/.*`, it expands to exclude my `~/.cache`, `~/.npm`, `~/.rustup`, .etc, which is great. However `tms` takes a long time to run because it decides to still dig through my `~/.cache` and the others. This PR fixes that.

As commentary, I've never written Rust before, nor any other non-GCed language, so "I have absolutely no idea what I'm doing" especially applies here. Nor do I have any experience with [`aho_corasick`](https://github.com/BurntSushi/aho-corasick) (sounds like some Jedi) - I based it off BurntSushi's answer [here](https://users.rust-lang.org/t/string-starts-with-in-any-one-in-the-vec/44108/5). I'm assuming the API changed since he wrote it in 2020 since `.anchored(true)` and `.auto_configure(...)` no longer exist.

Note that this is a breaking change.