### PR TITLE
Improvements on working with bare repos and worktrees

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,8 @@ fn main() -> Result<(), TmsError> {
     let repo_short_name = std::path::PathBuf::from(&repo_name)
         .file_name()
         .expect("None of the paths here should terminate in `..`")
-        .to_string()?;
+        .to_string()?
+        .replace('.', "_");
 
     // Get the tmux sessions
     let sessions = String::from_utf8(execute_tmux_command("tmux list-sessions -F #S").stdout)
@@ -89,10 +90,7 @@ fn main() -> Result<(), TmsError> {
         set_up_tmux_env(found_repo, &repo_short_name)?;
     }
 
-    execute_tmux_command(&format!(
-        "tmux switch-client -t {}",
-        repo_short_name.replace('.', "_")
-    ));
+    execute_tmux_command(&format!("tmux switch-client -t {}", repo_short_name));
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,7 +149,7 @@ pub(crate) fn set_up_tmux_env(repo: &Repository, repo_name: &str) -> Result<(), 
             ));
         }
         // Kill that first extra window
-        execute_tmux_command(&format!("tmux kill-window -t {repo_name}:1"));
+        execute_tmux_command(&format!("tmux kill-window -t {repo_name}:^"));
     } else {
         // Extra stuff?? I removed launching python environments here but that could be exposed in the configuration
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,10 @@ fn main() -> Result<(), TmsError> {
         set_up_tmux_env(found_repo, &repo_short_name)?;
     }
 
-    execute_tmux_command(&format!("tmux switch-client -t {}", repo_short_name));
+    let result = execute_tmux_command(&format!("tmux switch-client -t {repo_short_name}"));
+    if !result.status.success() {
+        execute_tmux_command(&format!("tmux attach -t {repo_short_name}"));
+    }
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ fn main() -> Result<(), TmsError> {
     let session_previously_existed = sessions.any(|line| {
         // tmux will return the output with extra ' and \n characters
         line.to_owned().retain(|char| char != '\'' && char != '\n');
-        line == repo_name
+        line == repo_short_name
     });
     if !session_previously_existed {
         execute_tmux_command(&format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ fn main() -> Result<(), TmsError> {
     // Get the tmux sessions
     let sessions = String::from_utf8(execute_tmux_command("tmux list-sessions -F #S").stdout)
         .into_report()
-        .expect("The tmux command static string should always be valid utf-9");
+        .expect("The tmux command static string should always be valid utf-8");
     let mut sessions = sessions.lines();
 
     // If the session already exists switch to it, else create the new session and then switch


### PR DESCRIPTION
Hi !
Thanks a lot for your work, that solves a lot of my recent problems with tmux.

These changes are a few things I had to do to make the tool work with my setup. They basically all stem from a bare repo I have whose name starts with a dot and that has worktrees I declared outside of the bare repo. (I was trying things...)

```shell
$ git clone --bare git@github.com:jrmoulton/tmux-sessionizer.git .tms
$ cd .tms
$ git worktree add ../main
$ git worktree add ../add-license-1
$ cd ../main
$ cargo run
```

This gives me `.tms` `main` and `add-license-1` in the list. I opted to just skip every worktree during the search for repos. It seems like this is the expected behaviour according to your readme but it could be a config option. I'm up to do it if you feel it's more sensible. c1a2974

When I select `.tms` in the list, The session opens with the default window instead of its worktrees. This is because of the leading dot which gets translated as an underscore by tmux when creating the session but it still tries to assign a window for each worktree to `.tms` instead of `_tms`. I make this translation before all commands so that the same name is used for each one. 5f880a6

I would always be missing the second window in the session and had the bare repo itself as the first window. This is because the window at index 1 was deleted instead of the first window. 5a3ddf1

The original name prefixed with a dot is used when checking if the session exists, this ends up launching the new-window commands again and duplicating windows. d4998f9 fixes that by using the underscore prefix for the check instead.

The command doesn't work if started without tmux open. This is because the switch-command is used and it fails if no client is open. 313feb9 checks the exitstatus from the switch-client command and runs the attach command if it fails.


This might be a bit too broad for a single PR so I can spread it if needed.