### PR TITLE
bump Cargo.toml version to 0.2.3 and sync Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tmux-sessionizer"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "aho-corasick 1.0.1",
  "clap 4.0.19",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmux-sessionizer"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Jared Moulton <jaredmoulton3@gmail.com>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
Fixes #18 

This synchronizes `Cargo.toml` and `Cargo.lock`, which allows allows the project to be built with `cargo build --frozen`.

I am doing this because I would like to update the version in `nixpkgs` but can't because nix builds rust projects with `--frozen`. Thanks!