### PR TITLE
fix: attach to tmux if currently not in tmux instead of switching

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,11 @@ fn main() -> Result<(), TmsError> {
         set_up_tmux_env(found_repo, &repo_short_name)?;
     }
 
+    if !is_in_tmux_session() {
+        execute_tmux_command(&format!("tmux attach -t {repo_short_name}"));
+        return Ok(());
+    }
+
     let result = execute_tmux_command(&format!("tmux switch-client -t {repo_short_name}"));
     if !result.status.success() {
         execute_tmux_command(&format!("tmux attach -t {repo_short_name}"));
@@ -164,6 +169,10 @@ pub fn execute_tmux_command(command: &str) -> process::Output {
         .stdin(process::Stdio::inherit())
         .output()
         .unwrap_or_else(|_| panic!("Failed to execute the tmux command `{command}`"))
+}
+
+fn is_in_tmux_session() -> bool {
+    std::env::var("TERM_PROGRAM").is_ok_and(|program| program == "tmux")
 }
 
 fn get_single_selection(list: String, preview: Option<&str>) -> Result<String, TmsError> {


### PR DESCRIPTION
Fixes #23 

Checks if currently in tmux with `TERM_PROGRAM == tmux` which was added to tmux [here](https://github.com/tmux/tmux/commit/4e053685df9f4d1c398148712ab0529a7e9d32e7)

If `false` attaches to tmux instead of switching session. 