### PR TITLE
Add option to show submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Options:
       --excluded <excluded dirs>...  As many directory names as desired to not be searched over
       --remove <remove dir>...       As many directory names to be removed from the exclusion list
       --full-path <true> <false>     Use the full path when displaying directories [possible values: true, false]
+      --search-submodules <true> <false> Also show initialized submodules [possible values: true, false]
   -h, --help                         Print help
 
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -56,6 +56,15 @@ pub(crate) fn create_app() -> ArgMatches {
                         .help("Use the full path when displaying directories")
                 )
                 .arg(
+                    Arg::new("search submodules")
+                        .required(false)
+                        .num_args(1)
+                        .value_names(["true", "false"])
+                        .value_parser(clap::value_parser!(bool))
+                        .long("search-submodules")
+                        .help("Also show initialized submodules")
+                )
+                .arg(
                     Arg::new("max depth")
                         .required(false)
                         .num_args(1..)
@@ -211,6 +220,10 @@ pub(crate) fn handle_sub_commands(cli_args: ArgMatches) -> Result<SubCommandGive
                 .get_one::<bool>("display full path")
                 .copied();
 
+            defaults.search_submodules = sub_cmd_matches
+                .get_one::<bool>("search submodules")
+                .copied();
+
             if let Some(dirs) = sub_cmd_matches.get_many::<String>("excluded dirs") {
                 let current_excluded = defaults.excluded_dirs;
                 match current_excluded {
@@ -241,6 +254,7 @@ pub(crate) fn handle_sub_commands(cli_args: ArgMatches) -> Result<SubCommandGive
                 excluded_dirs: defaults.excluded_dirs,
                 default_session: defaults.default_session,
                 display_full_path: defaults.display_full_path,
+                search_submodules: defaults.search_submodules,
                 sessions: defaults.sessions,
             };
 

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -26,6 +26,7 @@ pub struct Config {
     pub excluded_dirs: Option<Vec<String>>,
     pub default_session: Option<String>,
     pub display_full_path: Option<bool>,
+    pub search_submodules: Option<bool>,
     pub sessions: Option<Vec<Session>>,
 }
 


### PR DESCRIPTION
Hi!
Not sure how widely used submodules really are, but I do have a project where I sometimes only want to work on part of it, and being able to open a session in just one of the modules is rather convenient.
I am not an expert in git internals, so if this breaks anything else please let me know :sweat_smile: 