### PR TITLE
fix: remove trailing slash from repo path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,8 @@ fn main() -> Result<(), TmsError> {
         found_repo
             .workdir()
             .expect("bare repositories should all have parent directories")
+            .canonicalize()
+            .change_context(TmsError::IoError)?
             .to_string()?
     };
     let repo_short_name = std::path::PathBuf::from(&repo_name)


### PR DESCRIPTION
Quick follow-up to https://github.com/jrmoulton/tmux-sessionizer/pull/35 because I noticed it too late
Workdir paths seem to always have a trailing slash, which is displayed wrong in my fish shell prompt, and also different from how the paths looked before
Canonicalize removes these trailing slashes

Before:
![image](https://github.com/jrmoulton/tmux-sessionizer/assets/18437660/743f69f5-8086-437b-99da-f293f39750c2)
After:
![image](https://github.com/jrmoulton/tmux-sessionizer/assets/18437660/a5d4c527-ac54-4c19-842d-d51147a53e1a)

