### PR TITLE
Cleanup cli.rs

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -260,7 +260,7 @@ pub(crate) fn handle_sub_commands(cli_args: ArgMatches) -> Result<SubCommandGive
             Ok(SubCommandGiven::Yes)
         }
 
-        // The kill subcommand will kill the current session and switch to anther one
+        // The kill subcommand will kill the current session and switch to another one
         Some(("kill", _)) => {
             let defaults = confy::load::<Config>("tms", None)
                 .change_context(ConfigError::LoadError)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -277,14 +277,14 @@ pub(crate) fn handle_sub_commands(cli_args: ArgMatches) -> Result<SubCommandGive
             let sessions: Vec<&str> = sessions.lines().collect();
 
             let to_session = if defaults.default_session.is_some()
-                && sessions.contains(&defaults.default_session.clone().unwrap().as_str())
-                && current_session != defaults.default_session.clone().unwrap()
+                && sessions.contains(&defaults.default_session.as_deref().unwrap())
+                && current_session != defaults.default_session.as_deref().unwrap()
             {
-                defaults.default_session.unwrap()
+                defaults.default_session.as_deref().unwrap()
             } else if current_session != sessions[0] {
-                sessions[0].to_string()
+                sessions[0]
             } else {
-                sessions.get(1).unwrap_or_else(|| &sessions[0]).to_string()
+                sessions.get(1).unwrap_or_else(|| &sessions[0])
             };
             execute_tmux_command(&format!("tmux switch-client -t {to_session}"));
             execute_tmux_command(&format!("tmux kill-session -t {current_session}"));

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -251,17 +251,8 @@ pub(crate) fn handle_sub_commands(cli_args: ArgMatches) -> Result<SubCommandGive
                     None => todo!(),
                 }
             }
-            let config = Config {
-                search_paths: defaults.search_paths,
-                search_dirs: defaults.search_dirs,
-                excluded_dirs: defaults.excluded_dirs,
-                default_session: defaults.default_session,
-                display_full_path: defaults.display_full_path,
-                search_submodules: defaults.search_submodules,
-                sessions: defaults.sessions,
-            };
 
-            confy::store("tms", None, config)
+            confy::store("tms", None, defaults)
                 .change_context(ConfigError::WriteFailure)
                 .attach_printable("Failed to write the config file")
                 .change_context(TmsError::ConfigError)?;


### PR DESCRIPTION
Some commits that cleans up the code in `cli.rs`:
* Remove an unneeded move of the config data in the config subcommand
* Remove unneeded clone of the default_session in the kill subcommand
* Only load the config once in `handle_sub_commands`

Also fixed a misspelled comment.