### PR TITLE
fix: Load config if search_dirs is missing

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -186,29 +186,31 @@ pub(crate) fn handle_sub_commands(cli_args: ArgMatches) -> Result<SubCommandGive
                 None => Vec::new(),
             };
             config.search_dirs = match sub_cmd_matches.get_many::<String>("search paths") {
-                Some(paths) => paths
-                    .into_iter()
-                    .zip(max_depths.into_iter().chain(std::iter::repeat(&10)))
-                    .map(|(path, depth)| {
-                        let path = if path.ends_with('/') {
-                            let mut modified_path = path.clone();
-                            modified_path.pop();
-                            modified_path
-                        } else {
-                            path.clone()
-                        };
-                        shellexpand::full(&path)
-                            .map(|val| (val.to_string(), *depth))
-                            .change_context(TmsError::IoError)
-                    })
-                    .collect::<Result<Vec<(String, usize)>, TmsError>>()?
-                    .iter()
-                    .map(|(path, depth)| {
-                        canonicalize(path)
-                            .map(|val| SearchDirectory::new(val, *depth))
-                            .change_context(TmsError::IoError)
-                    })
-                    .collect::<Result<Vec<SearchDirectory>, TmsError>>()?,
+                Some(paths) => Some(
+                    paths
+                        .into_iter()
+                        .zip(max_depths.into_iter().chain(std::iter::repeat(&10)))
+                        .map(|(path, depth)| {
+                            let path = if path.ends_with('/') {
+                                let mut modified_path = path.clone();
+                                modified_path.pop();
+                                modified_path
+                            } else {
+                                path.clone()
+                            };
+                            shellexpand::full(&path)
+                                .map(|val| (val.to_string(), *depth))
+                                .change_context(TmsError::IoError)
+                        })
+                        .collect::<Result<Vec<(String, usize)>, TmsError>>()?
+                        .iter()
+                        .map(|(path, depth)| {
+                            canonicalize(path)
+                                .map(|val| SearchDirectory::new(val, *depth))
+                                .change_context(TmsError::IoError)
+                        })
+                        .collect::<Result<Vec<SearchDirectory>, TmsError>>()?,
+                ),
                 None => config.search_dirs,
             };
 

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -25,8 +25,8 @@ pub struct Config {
     pub display_full_path: Option<bool>,
     pub search_submodules: Option<bool>,
     pub excluded_dirs: Option<Vec<String>>,
-    pub search_paths: Vec<String>, // old format, deprecated
-    pub search_dirs: Vec<SearchDirectory>,
+    pub search_paths: Option<Vec<String>>, // old format, deprecated
+    pub search_dirs: Option<Vec<SearchDirectory>>,
     pub sessions: Option<Vec<Session>>,
 }
 


### PR DESCRIPTION
Make both search_dirs and search_paths optional so missing config can be handled by the already existing checks in main.rs.

fixes #37