### PR TITLE
Bump version to 0.3.2 and sync Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,7 +1088,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tmux-sessionizer"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "aho-corasick",
  "clap 4.4.11",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmux-sessionizer"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Jared Moulton <jaredmoulton3@gmail.com>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
Hi, I swear I'm not stalking this repo ( :sweat_smile: ), I just happened to update my system, and using the nix flake the package no longer builds because of this. I think something similar happened during one of the 0.2 releases so I just did the same as the person did back then.