### PR TITLE
flake: add support for aarch64-linux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
     flake-parts.lib.mkFlake {inherit inputs;} {
       systems = [
         "x86_64-linux"
+        "aarch64-linux"
         "x86_64-darwin"
         "aarch64-darwin"
       ];


### PR DESCRIPTION
![image](https://github.com/jrmoulton/tmux-sessionizer/assets/18437660/c77581ba-143c-46a2-9a47-592d79c3e57f)
Unless there was a reason this was left out? Sometimes I use a linux vm with nix on a macbook, and it seems to work just fine, so it would be convenient to have this