### PR TITLE
Improvements

### DIFF
--- a/src/repos.rs
+++ b/src/repos.rs
@@ -2,21 +2,12 @@ use git2::Repository;
 use std::collections::HashMap;
 
 pub trait RepoContainer {
-    fn repo_string(&self) -> String;
     fn find_repo(&self, name: &str) -> Option<&Repository>;
     fn insert_repo(&mut self, name: String, repo: Repository);
     fn list(&self) -> Vec<String>;
 }
 
 impl RepoContainer for HashMap<String, Repository> {
-    fn repo_string(&self) -> String {
-        let mut return_string = String::new();
-        for name in self.keys() {
-            return_string.push_str(&format!("{}\n", name));
-        }
-        return_string
-    }
-
     fn find_repo(&self, name: &str) -> Option<&Repository> {
         self.get(name)
     }

--- a/src/repos.rs
+++ b/src/repos.rs
@@ -26,6 +26,9 @@ impl RepoContainer for HashMap<String, Repository> {
     }
 
     fn list(&self) -> Vec<String> {
-        self.keys().map(|s| s.to_owned()).collect()
+        let mut list: Vec<String> = self.keys().map(|s| s.to_owned()).collect();
+        list.sort();
+
+        list
     }
 }


### PR DESCRIPTION
* Sort the repo list before adding it to the picker.
* Remove no longer used function from RepoContainer.
* Partial solution to repo name duplicates, only works for repo names not full paths currently.