### PR TITLE
Add refresh command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ directory
 
 `bind C-w command-prompt -p "Rename active session to: " "run-shell 'tms rename %1'"`.
 
+### The `tms refresh` command
+
+Using this command you can automatically generate missing worktree windows for the active session or a provided `session_name`. 
+
+`tms refresh <session_name>`
+
+`bind C-r "run-shell 'tms refresh'"`.
+
 ### CLI overview
 
 Use `tms --help`
@@ -72,6 +80,8 @@ Commands:
   sessions  Show running tmux sessions with asterisk on the current session
   rename    Rename the active session and the working directory
   help      Print this message or the help of the given subcommand(s)
+  refresh   Creates new worktree windows for the selected session
+
 
 Options:
   -h, --help     Print help

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ Commands:
   kill      Kill the current tmux session and jump to another
   sessions  Show running tmux sessions with asterisk on the current session
   rename    Rename the active session and the working directory
-  help      Print this message or the help of the given subcommand(s)
   refresh   Creates new worktree windows for the selected session
+  help      Print this message or the help of the given subcommand(s)
 
 
 Options:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,11 +1,12 @@
 use std::{collections::HashMap, fs::canonicalize};
 
 use crate::{
-    configs::Config, configs::SearchDirectory, execute_command, execute_tmux_command,
-    get_single_selection, TmsError,
+    configs::Config, configs::SearchDirectory, dirty_paths::DirtyUtf8Path, execute_command,
+    execute_tmux_command, get_single_selection, TmsError,
 };
 use clap::{Arg, ArgMatches, Command};
 use error_stack::{Result, ResultExt};
+use git2::Repository;
 
 pub(crate) fn create_app() -> ArgMatches {
     Command::new("tms")
@@ -99,6 +100,14 @@ pub(crate) fn create_app() -> ArgMatches {
                 Arg::new("name")
                 .required(true)
                 .help("The new session's name")
+            )
+        )
+        .subcommand(Command::new("refresh")
+            .about("Creates new worktree windows for the selected session")
+            .arg(
+                Arg::new("name")
+                .required(false)
+                .help("The session's name. If not provided gets current session")
             )
         )
         .get_matches()
@@ -405,6 +414,61 @@ pub(crate) fn handle_sub_commands(cli_args: ArgMatches) -> Result<SubCommandGive
 
             execute_tmux_command(&format!("tmux rename-session {}", new_session_name));
             execute_tmux_command(&format!("tmux attach -c {}", new_session_path));
+            Ok(SubCommandGiven::Yes)
+        }
+        Some(("refresh", sub_cmd_matches)) => {
+            let session_name = sub_cmd_matches
+                .get_one::<String>("name")
+                .unwrap_or(
+                    &String::from_utf8(execute_tmux_command("tmux display-message -p '#S'").stdout)
+                        .unwrap(),
+                )
+                .trim()
+                .replace("'", "");
+            // For each window there should be the branch names
+            let session_path = String::from_utf8(
+                execute_tmux_command("tmux display-message -p '#{session_path}'").stdout,
+            )
+            .unwrap()
+            .trim()
+            .replace("'", "");
+            let existing_window_names: Vec<_> = String::from_utf8(
+                execute_tmux_command(&format!(
+                    "tmux list-windows -t {session_name} -F '#{{window_name}}'"
+                ))
+                .stdout,
+            )
+            .unwrap()
+            .lines()
+            .map(|line| line.replace("'", ""))
+            .collect();
+
+            if let Ok(repository) = Repository::open(session_path) {
+                if let Ok(worktrees) = repository.worktrees() {
+                    for worktree_name in worktrees.iter().filter_map(|f| f) {
+                        if existing_window_names.contains(&String::from(worktree_name)) {
+                            continue;
+                        }
+                        let path_to_tree = repository
+                            .find_worktree(worktree_name)
+                            .change_context(TmsError::GitError)?
+                            .path()
+                            .to_string()?;
+                        execute_command(
+                            "tmux",
+                            vec![
+                                String::from("new-window"),
+                                String::from("-t"),
+                                String::from(session_name.clone()),
+                                String::from("-c"),
+                                String::from(path_to_tree),
+                                String::from("-n"),
+                                String::from(worktree_name),
+                            ],
+                        );
+                    }
+                }
+            }
             Ok(SubCommandGiven::Yes)
         }
         _ => Ok(SubCommandGiven::No(config)),


### PR DESCRIPTION
Hi its me again :)
The command generates new tmux worktree windows in a session.
so 
```
tms refresh
```
Wil create missing worktrees windows in the current directory.
```
tms refresh session-name 
```
Will create missing worktree windows for the session `session-name`

https://github.com/jrmoulton/tmux-sessionizer/assets/35531567/6036fb8e-22b3-4225-a214-cc07836ab1fd

Note: This differs a bit from the current implementation as I don't check if the repository is bare. 
In my opinion the user should be able to decide if he wants to use bare with worktree or normal with worktree. (I am such a user that uses both) and I would argue that someone who uses the git feature has made his mind up.
So probably provide a config option or change the default behaviour. 

Currently the implementation is kind of a duplicate to the startup one. So further work should be to extract the generation of windows in a utility function that is called on refresh call and on first session generation. 

Cheers

