### PR TITLE
fix(build): version discrepancy between Cargo.toml and Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,7 +938,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tmux-sessionizer"
-version = "0.4.9"
+version = "0.4.1"
 dependencies = [
  "aho-corasick",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmux-sessionizer"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Jared Moulton <jaredmoulton3@gmail.com>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
The version in Cargo.lock is wrong, making version 4.0.0 impossible to package for Nix without applying a patch.

:thinking: perhaps a GitHub action that runs `cargo build` and fails if `Cargo.lock` changes would be useful?