### PR TITLE
remap ctrl-k and ctrl-j keybinds

### DIFF
--- a/src/picker.rs
+++ b/src/picker.rs
@@ -106,11 +106,6 @@ impl Picker {
                                 return Ok(Some(selected));
                             }
                         }
-                        KeyCode::Char('j') if key.modifiers == KeyModifiers::CONTROL => {
-                            if let Some(selected) = self.get_selected() {
-                                return Ok(Some(selected));
-                            }
-                        }
                         KeyCode::Delete => self.delete(),
                         KeyCode::Char('d') if key.modifiers == KeyModifiers::CONTROL => {
                             self.delete()
@@ -121,15 +116,18 @@ impl Picker {
                         KeyCode::Char('u') if key.modifiers == KeyModifiers::CONTROL => {
                             self.delete_to_line(false)
                         }
-                        KeyCode::Char('k') if key.modifiers == KeyModifiers::CONTROL => {
-                            self.delete_to_line(true)
-                        }
                         KeyCode::Up => self.move_up(),
                         KeyCode::Char('p') if key.modifiers == KeyModifiers::CONTROL => {
                             self.move_up()
                         }
+                        KeyCode::Char('k') if key.modifiers == KeyModifiers::CONTROL => {
+                            self.move_up()
+                        }
                         KeyCode::Down => self.move_down(),
                         KeyCode::Char('n') if key.modifiers == KeyModifiers::CONTROL => {
+                            self.move_down()
+                        }
+                        KeyCode::Char('j') if key.modifiers == KeyModifiers::CONTROL => {
                             self.move_down()
                         }
                         KeyCode::Char('a') if key.modifiers == KeyModifiers::CONTROL => {


### PR DESCRIPTION
This PR maps `ctrl-k` and `ctrl-j` to up and down respectively, bringing it into line with fzf.

Unfortunately, this overwrites the existing behaviour:

- `ctrl-j` was equivalent to hitting enter
- `ctrl-k` deleted all characters after the cursor in the search bar.

I'm open to suggestions as to which keys these should be mapped to - I didn't want to just pick random ones.

Closes #74 