### PR TITLE
fix(build): update version + lockfile and ensure correctness in ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,15 @@ jobs:
       - name: Install dependencies
         run: |
           ${{ matrix.packages_install }}
+      - name: Get version
+        run: echo "VERSION=$(git describe --abbrev=0 --tags)" >> $GITHUB_ENV
+      - name: Ensure version in Cargo.toml is correct
+        if: startsWith(github.ref, 'refs/tags/')
+        # Fails if the version does not match
+        run: grep -q "name = \"tmux-sessionizer\"\nversion = \"${VERSION//v}\"" Cargo.toml
+      - name: Ensure Cargo.lock is up to date
+        # Fails if lockfile needs to be updated
+        run: cargo generate-lockfile --frozen
       - name: Build artifacts
         run: |
           # Actually do builds and make zips and whatnot

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,7 +938,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tmux-sessionizer"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "aho-corasick",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmux-sessionizer"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Jared Moulton <jaredmoulton3@gmail.com>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
Hey :wave: 

I noticed your last release and wanted to package it for nixpkgs.
It looks like you forgot to update the version in Cargo.toml + Cargo.lock again.

This PR adds some safety, as discussed in #67, by:

- Extracting the version from the git tag and storing it in the `VERSION` environment variable.
- Checking that it is set correctly in Cargo.toml (we have to remove the `v` prefix - will fail if not).
- Ensure the lockfile is up to date (will fail if not).

I've also bumped the version in Cargo.toml to 0.4.3 and updated the lockfile.
Would you be open to pushing a 0.4.3 tag, so I can package this for nixpkgs?
