### PR TITLE
Relative paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,6 +949,7 @@ dependencies = [
  "git2",
  "nucleo",
  "once_cell",
+ "pathdiff",
  "ratatui",
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ dirs = "5.0.1"
 nucleo = "0.4.0"
 ratatui = "0.26.0"
 crossterm = "0.27.0"
+pathdiff = "0.2.1"
 
 [[bin]]
 name = "tms"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -57,9 +57,6 @@ pub struct ConfigCommand {
     #[arg(long = "remove", value_name = "remove dir", num_args = 1..)]
     /// As many directory names to be removed from exclusion list
     remove_dir: Option<Vec<String>>,
-    #[arg(long = "full-path", value_name = "true | false")]
-    /// Use the full path when displaying directories
-    display_full_path: Option<bool>,
     #[arg(long = "path-view", value_name = "name_only | relative | absolute")]
     /// Select how the path should be displayed
     path_view: Option<PathView>,
@@ -329,10 +326,6 @@ fn config_command(args: &ConfigCommand, mut config: Config) -> Result<(), TmsErr
         .map(|val| val.replace('.', "_"))
     {
         config.default_session = Some(default_session);
-    }
-
-    if let Some(_) = args.display_full_path {
-        println!("This command is deprecated, please use `path_view`.")
     }
 
     if let Some(display) = &args.path_view {

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ fn main() -> Result<(), TmsError> {
     let repos = find_repos(
         config.search_dirs()?,
         config.excluded_dirs,
-        config.display_full_path,
+        config.path_view,
         config.search_submodules,
         config.recursive_submodules,
     )?;


### PR DESCRIPTION
I made a proposal for the issue of https://github.com/jrmoulton/tmux-sessionizer/issues/26.

There is now the new command-line argument `path_view` that you can set to `name-only` (default), `absolute` (like `full-path`) and `relative`. Relative will then give a name with the relative path to original `search_dir`.

Until now, old settings from `full_path` are ignored. Should this be handled? And if yes, where?