### PR TITLE
feat: attach path to `fs::read_dir` errors

### DIFF
--- a/src/repos.rs
+++ b/src/repos.rs
@@ -84,8 +84,9 @@ pub fn find_repos(
             }
             repos.insert_repo(name, repo);
         } else if file.path.is_dir() && file.depth > 0 {
-            let read_dir = fs::read_dir(file.path)
-                .change_context(TmsError::IoError)?
+            let read_dir = fs::read_dir(&file.path)
+                .change_context(TmsError::IoError)
+                .attach_printable_lazy(|| format!("Could not read directory {:?}", file.path))?
                 .map(|dir_entry| dir_entry.expect("Found non-valid utf8 path").path());
             for dir in read_dir {
                 to_search.push_back(SearchDirectory::new(dir, file.depth - 1))


### PR DESCRIPTION
My use case is probably a bit niche, but I store most of my git repos in a separate case-sensitive APFS volume on my Mac. There are a number of directories created by the system that are unreadable by my user (like ` .fseventsd`). I can work around it by adding entries to `excluded_dirs`, but this makes it easier to tell what's going on :smile:

```
Error: IO Error
├╴at src/repos.rs:88:18
├╴Could not read directory "/Volumes/dev/.fseventsd"
│
╰─▶ Permission denied (os error 13)
    ╰╴at src/repos.rs:88:18
```