### PR TITLE
Add support for running script on session creation

### DIFF
--- a/src/configs.rs
+++ b/src/configs.rs
@@ -1,7 +1,7 @@
 use clap::ValueEnum;
 use error_stack::ResultExt;
 use serde_derive::{Deserialize, Serialize};
-use std::{env, fmt::Display, fs::canonicalize, io::Write, path::PathBuf};
+use std::{collections::HashMap, env, fmt::Display, fs::canonicalize, io::Write, path::PathBuf};
 
 use ratatui::style::{Color, Style};
 
@@ -47,6 +47,7 @@ pub struct Config {
     pub picker_colors: Option<PickerColorConfig>,
     pub shortcuts: Option<Keymap>,
     pub bookmarks: Option<Vec<String>>,
+    pub session_configs: Option<HashMap<String, SessionConfig>>,
 }
 
 impl Config {
@@ -341,4 +342,9 @@ impl ValueEnum for SessionSortOrderConfig {
             }
         }
     }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct SessionConfig {
+    pub create_script: Option<PathBuf>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ fn main() -> Result<()> {
         };
 
     if let Some(session) = sessions.find_session(&selected_str) {
-        session.switch_to(&tmux)?;
+        session.switch_to(&tmux, &config)?;
     }
 
     Ok(())

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -61,6 +61,7 @@ fn tms_config() -> anyhow::Result<()> {
         }),
         shortcuts: None,
         bookmarks: None,
+        session_configs: None,
     };
 
     let mut tms = Command::cargo_bin("tms")?;


### PR DESCRIPTION
Looks for a script named .tms-create in the path of the session being created. Runs it by sending keys to the first window's top pane. The script needs to be executable.

This can be overridden by adding something like the following to the config file:
[session-configs.session_name]
create_script = "my-create.sh"

fixes #33