### PR TITLE
Add command to initialize new git repo

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,10 @@
             openssl
             pkg-config
           ]
-          ++ lib.optionals stdenv.isDarwin [ libgit2 ];
+          ++ lib.optionals stdenv.isDarwin [
+            libgit2
+            darwin.Security
+           ];
         };
       };
       flake = {


### PR DESCRIPTION
works analogous to clone-repo in that it simply uses the first configured search path to initialize the repo, but in this case slashes are supported (all directories will be created automatically)