### PR TITLE
clone/init repo: show directory picker if more than one is configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ Commands:
   sessions    Show running tmux sessions with asterisk on the current session
   rename      Rename the active session and the working directory
   refresh     Creates new worktree windows for the selected session
-  clone-repo  Clone repository into the first search path and create a new session for it
+  clone-repo  Clone repository and create a new session for it
+  init-repo   Initialize empty repository
+  bookmark    Bookmark a directory so it is available to select along with the Git repositories
   help        Print this message or the help of the given subcommand(s)
 
 Options:

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -1,5 +1,6 @@
 use std::{
     io::{self, Stdout},
+    process,
     rc::Rc,
     sync::Arc,
 };
@@ -36,6 +37,7 @@ use crate::{
 pub enum Preview {
     SessionPane,
     None,
+    Directory,
 }
 
 pub struct Picker<'a> {
@@ -275,6 +277,12 @@ impl<'a> Picker<'a> {
             if let Some(item) = snapshot.get_matched_item(index as u32) {
                 let output = match self.preview {
                     Preview::SessionPane => self.tmux.capture_pane(item.data),
+                    Preview::Directory => process::Command::new("ls")
+                        .args(["-1", item.data])
+                        .output()
+                        .unwrap_or_else(|_| {
+                            panic!("Failed to execute the command for directory: {}", item.data)
+                        }),
                     Preview::None => panic!("preview rendering should not have occured"),
                 };
 


### PR DESCRIPTION
some expansion on #115, related to #114 
if multiple search directories are configured, `init-repo` and `clone-repo` will now show a picker with all configured search dirs, with a simple preview to the side