### PR TITLE
fix window pane capture

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -303,7 +303,7 @@ fn windows_command(config: &Config, tmux: &Tmux) -> Result<()> {
         .map(|s| s.to_string())
         .collect();
 
-    if let Some(target_window) = get_single_selection(&windows, Preview::SessionPane, config, tmux)?
+    if let Some(target_window) = get_single_selection(&windows, Preview::WindowPane, config, tmux)?
     {
         if let Some((windex, _)) = target_window.split_once(' ') {
             tmux.select_window(windex);

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -36,6 +36,7 @@ use crate::{
 
 pub enum Preview {
     SessionPane,
+    WindowPane,
     None,
     Directory,
 }
@@ -277,6 +278,12 @@ impl<'a> Picker<'a> {
             if let Some(item) = snapshot.get_matched_item(index as u32) {
                 let output = match self.preview {
                     Preview::SessionPane => self.tmux.capture_pane(item.data),
+                    Preview::WindowPane => self.tmux.capture_pane(
+                        item.data
+                            .split_once(' ')
+                            .map(|val| val.0)
+                            .unwrap_or_default(),
+                    ),
                     Preview::Directory => process::Command::new("ls")
                         .args(["-1", item.data])
                         .output()


### PR DESCRIPTION
window pane capture was previously broken because it was including the pane name along with the pane id