### PR TITLE
Clean up picker rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,9 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bstr"
@@ -221,6 +224,7 @@ dependencies = [
  "itoa",
  "rustversion",
  "ryu",
+ "serde",
  "static_assertions",
 ]
 
@@ -813,6 +817,7 @@ dependencies = [
  "itertools",
  "lru",
  "paste",
+ "serde",
  "strum",
  "strum_macros",
  "unicode-segmentation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ config = { version = "0.14", default-features = false, features = ["toml"] }
 toml = "0.8"
 dirs = "5.0.1"
 nucleo = "0.5.0"
-ratatui = "0.28"
+ratatui = { version = "0.28", features = ["serde"] }
 crossterm = "0.28"
 clap_complete = "4.5"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,6 +18,7 @@ use clap::{Args, Command, CommandFactory, Parser, Subcommand};
 use clap_complete::{generate, Generator, Shell};
 use error_stack::ResultExt;
 use git2::{build::RepoBuilder, FetchOptions, RemoteCallbacks, Repository};
+use ratatui::style::Color;
 
 #[derive(Debug, Parser)]
 #[command(author, version)]
@@ -89,19 +90,19 @@ pub struct ConfigCommand {
     max_depths: Option<Vec<usize>>,
     #[arg(long, value_name = "#rrggbb")]
     /// Background color of the highlighted item in the picker
-    picker_highlight_color: Option<String>,
+    picker_highlight_color: Option<Color>,
     #[arg(long, value_name = "#rrggbb")]
     /// Text color of the hightlighted item in the picker
-    picker_highlight_text_color: Option<String>,
+    picker_highlight_text_color: Option<Color>,
     #[arg(long, value_name = "#rrggbb")]
     /// Color of the borders between widgets in the picker
-    picker_border_color: Option<String>,
+    picker_border_color: Option<Color>,
     #[arg(long, value_name = "#rrggbb")]
     /// Color of the item count in the picker
-    picker_info_color: Option<String>,
+    picker_info_color: Option<Color>,
     #[arg(long, value_name = "#rrggbb")]
     /// Color of the prompt in the picker
-    picker_prompt_color: Option<String>,
+    picker_prompt_color: Option<Color>,
     #[arg(long, value_name = "Alphabetical | LastAttached")]
     /// Set the sort order of the sessions in the switch command
     session_sort_order: Option<SessionSortOrderConfig>,
@@ -392,27 +393,27 @@ fn config_command(args: &ConfigCommand, mut config: Config) -> Result<()> {
 
     if let Some(color) = &args.picker_highlight_color {
         let mut picker_colors = config.picker_colors.unwrap_or_default();
-        picker_colors.highlight_color = Some(color.to_string());
+        picker_colors.highlight_color = Some(*color);
         config.picker_colors = Some(picker_colors);
     }
     if let Some(color) = &args.picker_highlight_text_color {
         let mut picker_colors = config.picker_colors.unwrap_or_default();
-        picker_colors.highlight_text_color = Some(color.to_string());
+        picker_colors.highlight_text_color = Some(*color);
         config.picker_colors = Some(picker_colors);
     }
     if let Some(color) = &args.picker_border_color {
         let mut picker_colors = config.picker_colors.unwrap_or_default();
-        picker_colors.border_color = Some(color.to_string());
+        picker_colors.border_color = Some(*color);
         config.picker_colors = Some(picker_colors);
     }
     if let Some(color) = &args.picker_info_color {
         let mut picker_colors = config.picker_colors.unwrap_or_default();
-        picker_colors.info_color = Some(color.to_string());
+        picker_colors.info_color = Some(*color);
         config.picker_colors = Some(picker_colors);
     }
     if let Some(color) = &args.picker_prompt_color {
         let mut picker_colors = config.picker_colors.unwrap_or_default();
-        picker_colors.prompt_color = Some(color.to_string());
+        picker_colors.prompt_color = Some(*color);
         config.picker_colors = Some(picker_colors);
     }
 

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -4,7 +4,6 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use serde::de::Error as DeError;
 use serde::ser::Error as SerError;
 use serde::{Deserialize, Serialize};
-use serde_derive::{Deserialize, Serialize};
 
 use crate::error::TmsError;
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,6 +1,7 @@
 use assert_cmd::Command;
 use pretty_assertions::assert_eq;
-use std::fs;
+use ratatui::style::Color;
+use std::{fs, str::FromStr};
 use tempfile::tempdir;
 use tms::configs::{Config, PickerColorConfig, SearchDirectory, SessionSortOrderConfig};
 
@@ -32,11 +33,11 @@ fn tms_config() -> anyhow::Result<()> {
     let depth = 1;
     let default_session = String::from("my_default_session");
     let excluded_dir = String::from("/exclude/this/directory");
-    let picker_highlight_color = String::from("#aaaaaa");
-    let picker_highlight_text_color = String::from("#bbbbbb");
-    let picker_border_color = String::from("#cccccc");
-    let picker_info_color = String::from("#dddddd");
-    let picker_prompt_color = String::from("#eeeeee");
+    let picker_highlight_color = Color::from_str("#aaaaaa")?;
+    let picker_highlight_text_color = Color::from_str("#bbbbbb")?;
+    let picker_border_color = Color::from_str("#cccccc")?;
+    let picker_info_color = Color::from_str("green")?;
+    let picker_prompt_color = Color::from_str("#eeeeee")?;
 
     let expected_config = Config {
         default_session: Some(default_session.clone()),
@@ -53,11 +54,11 @@ fn tms_config() -> anyhow::Result<()> {
         )]),
         sessions: None,
         picker_colors: Some(PickerColorConfig {
-            highlight_color: Some(picker_highlight_color.clone()),
-            highlight_text_color: Some(picker_highlight_text_color.clone()),
-            border_color: Some(picker_border_color.clone()),
-            info_color: Some(picker_info_color.clone()),
-            prompt_color: Some(picker_prompt_color.clone()),
+            highlight_color: Some(picker_highlight_color),
+            highlight_text_color: Some(picker_highlight_text_color),
+            border_color: Some(picker_border_color),
+            info_color: Some(picker_info_color),
+            prompt_color: Some(picker_prompt_color),
         }),
         shortcuts: None,
         bookmarks: None,
@@ -88,15 +89,15 @@ fn tms_config() -> anyhow::Result<()> {
             "--excluded",
             &excluded_dir,
             "--picker-highlight-color",
-            &picker_highlight_color,
+            &picker_highlight_color.to_string(),
             "--picker-highlight-text-color",
-            &picker_highlight_text_color,
+            &picker_highlight_text_color.to_string(),
             "--picker-border-color",
-            &picker_border_color,
+            &picker_border_color.to_string(),
             "--picker-info-color",
-            &picker_info_color,
+            &picker_info_color.to_string(),
             "--picker-prompt-color",
-            &picker_prompt_color,
+            &picker_prompt_color.to_string(),
         ]);
 
     tms.assert().success().code(0);


### PR DESCRIPTION
Make use of the serde support in ratatui to parse colors.
Have the default colors in one place instead of spread out all over the place.
Move out selection update from the render function.
Move out the matcher update from the render function.
Simplify the selection if statement in render_preview function.