### PR TITLE
fix: shellexpand final path in pick_search_path

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -619,7 +619,13 @@ fn pick_search_path(config: &Config, tmux: &Tmux) -> Result<Option<PathBuf>> {
             .attach_printable("No search path configured")?;
         Some(first.clone())
     };
-    Ok(path.map(PathBuf::from))
+
+    let expanded = path
+        .as_ref()
+        .map(|path| shellexpand::full(path).change_context(TmsError::IoError))
+        .transpose()?
+        .map(|path| PathBuf::from(path.as_ref()));
+    Ok(expanded)
 }
 
 fn clone_repo_command(args: &CloneRepoCommand, config: Config, tmux: &Tmux) -> Result<()> {


### PR DESCRIPTION
The `clone-repo` and `init-repo` commands do not shell expand the search path they pick from the configuration via `pick_search_path`.

For example, my configuration is:

```toml
[[search_dirs]]
path = "~/src"
```

and below command:

```sh
tms clone-repo https://github.com/repo/repo
```

would result in the repo being cloned to `$PWD/~/src/repo` rather than `/home/user/src/repo`.

I'm assuming only the final search path that is picked in `pick_search_path` should be expanded such that the interactive picker still shows the unexpanded, easier to read paths first. 