### PR TITLE
`clone-repo`: Display clone repo progress

### DIFF
--- a/src/clone.rs
+++ b/src/clone.rs
@@ -1,0 +1,159 @@
+use std::{
+    fmt::Display,
+    io::{stdout, Stdout, Write},
+    path::Path,
+    time::{Duration, Instant},
+};
+
+use crate::{error::TmsError, Result};
+
+use crossterm::{cursor, terminal, ExecutableCommand};
+use error_stack::ResultExt;
+use git2::{build::RepoBuilder, FetchOptions, Progress, RemoteCallbacks, Repository};
+
+const UPDATE_INTERVAL: Duration = Duration::from_millis(300);
+
+struct Rate(usize);
+
+impl Display for Rate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.0 > 1024 * 1024 {
+            let rate = self.0 as f64 / 1024.0 / 1024.0;
+            write!(f, "{:.2} MB/s", rate)
+        } else {
+            let rate = self.0 as f64 / 1024.0;
+            write!(f, "{:.2} kB/s", rate)
+        }
+    }
+}
+
+struct CloneSnapshot {
+    time: Instant,
+    bytes_transferred: usize,
+    stdout: Stdout,
+    lines: u16,
+}
+
+impl CloneSnapshot {
+    pub fn new() -> Self {
+        let stdout = stdout();
+        Self {
+            time: Instant::now(),
+            bytes_transferred: 0,
+            stdout,
+            lines: 0,
+        }
+    }
+
+    pub fn update(&mut self, progress: &Progress) -> Result<()> {
+        let now = Instant::now();
+        let difference = now.duration_since(self.time);
+        if difference < UPDATE_INTERVAL {
+            return Ok(());
+        }
+
+        let transferred = progress.received_bytes() - self.bytes_transferred;
+        let rate = Rate(transferred / (difference.as_millis() as usize) * 1000);
+
+        let network_pct = (100 * progress.received_objects()) / progress.total_objects();
+        let index_pct = (100 * progress.indexed_objects()) / progress.total_objects();
+
+        let total = (network_pct + index_pct) / 2;
+
+        if self.lines > 0 {
+            self.stdout
+                .execute(cursor::MoveUp(self.lines))
+                .change_context(TmsError::IoError)?;
+            self.stdout
+                .execute(terminal::Clear(terminal::ClearType::FromCursorDown))
+                .change_context(TmsError::IoError)?;
+        }
+
+        let mut lines = 0;
+
+        if network_pct < 100 {
+            writeln!(
+                self.stdout,
+                "Received {:3}% ({:5}/{:5})",
+                network_pct,
+                progress.received_objects(),
+                progress.total_objects(),
+            )
+            .change_context(TmsError::IoError)?;
+            lines += 1
+        }
+
+        if index_pct < 100 {
+            writeln!(
+                self.stdout,
+                "Indexed {:3}% ({:5}/{:5})",
+                index_pct,
+                progress.indexed_objects(),
+                progress.total_objects(),
+            )
+            .change_context(TmsError::IoError)?;
+            lines += 1;
+        }
+
+        if network_pct < 100 {
+            writeln!(self.stdout, "{} ", rate).change_context(TmsError::IoError)?;
+            lines += 1;
+        }
+
+        if progress.total_objects() > 0 && progress.received_objects() == progress.total_objects() {
+            let delta_pct = (100 * progress.indexed_deltas()) / progress.total_deltas();
+            writeln!(
+                self.stdout,
+                "Resolving deltas {:3}% ({:5}/{:5})",
+                delta_pct,
+                progress.indexed_deltas(),
+                progress.total_deltas()
+            )
+            .change_context(TmsError::IoError)?;
+            lines += 1;
+        }
+        write!(self.stdout, "{:3}% ", total).change_context(TmsError::IoError)?;
+        for _ in 0..(total / 3) {
+            write!(self.stdout, "█").change_context(TmsError::IoError)?;
+        }
+        writeln!(self.stdout).change_context(TmsError::IoError)?;
+        lines += 1;
+        self.time = Instant::now();
+        self.bytes_transferred = progress.received_bytes();
+        self.lines = lines;
+
+        Ok(())
+    }
+}
+
+pub fn git_clone(repo: &str, target: &Path) -> Result<Repository> {
+    let mut callbacks = RemoteCallbacks::new();
+    callbacks.credentials(git_credentials_callback);
+
+    let mut state = CloneSnapshot::new();
+    callbacks.transfer_progress(move |progress| {
+        state.update(&progress).ok();
+        true
+    });
+    let mut fo = FetchOptions::new();
+    fo.remote_callbacks(callbacks);
+    let mut builder = RepoBuilder::new();
+    builder.fetch_options(fo);
+
+    builder
+        .clone(repo, target)
+        .change_context(TmsError::GitError)
+}
+
+fn git_credentials_callback(
+    user: &str,
+    user_from_url: Option<&str>,
+    _cred: git2::CredentialType,
+) -> std::result::Result<git2::Cred, git2::Error> {
+    let user = match user_from_url {
+        Some(user) => user,
+        None => user,
+    };
+
+    git2::Cred::ssh_key_from_agent(user)
+}

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -49,6 +49,7 @@ pub struct Config {
     pub bookmarks: Option<Vec<String>>,
     pub session_configs: Option<HashMap<String, SessionConfig>>,
     pub marks: Option<HashMap<String, String>>,
+    pub clone_repo_switch: Option<CloneRepoSwitchConfig>,
 }
 
 impl Config {
@@ -363,6 +364,29 @@ impl ValueEnum for SessionSortOrderConfig {
             }
             SessionSortOrderConfig::LastAttached => {
                 Some(clap::builder::PossibleValue::new("LastAttached"))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub enum CloneRepoSwitchConfig {
+    Always,
+    Never,
+    Foreground,
+}
+
+impl ValueEnum for CloneRepoSwitchConfig {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[Self::Always, Self::Never, Self::Foreground]
+    }
+
+    fn to_possible_value(&self) -> Option<clap::builder::PossibleValue> {
+        match self {
+            CloneRepoSwitchConfig::Always => Some(clap::builder::PossibleValue::new("Always")),
+            CloneRepoSwitchConfig::Never => Some(clap::builder::PossibleValue::new("Never")),
+            CloneRepoSwitchConfig::Foreground => {
+                Some(clap::builder::PossibleValue::new("Foreground"))
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cli;
+mod clone;
 pub mod configs;
 pub mod dirty_paths;
 pub mod error;

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -76,6 +76,17 @@ impl Tmux {
         Tmux::stdout_to_string(output)
     }
 
+    pub fn current_session(&self, format: &str) -> String {
+        let output = self.execute_tmux_command(&[
+            "list-sessions",
+            "-F",
+            format,
+            "-f",
+            "#{session_attached}",
+        ]);
+        Tmux::stdout_to_string(output)
+    }
+
     pub fn kill_session(&self, session: &str) -> process::Output {
         self.execute_tmux_command(&["kill-session", "-t", session])
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3,7 +3,9 @@ use pretty_assertions::assert_eq;
 use ratatui::style::Color;
 use std::{fs, str::FromStr};
 use tempfile::tempdir;
-use tms::configs::{Config, PickerColorConfig, SearchDirectory, SessionSortOrderConfig};
+use tms::configs::{
+    CloneRepoSwitchConfig, Config, PickerColorConfig, SearchDirectory, SessionSortOrderConfig,
+};
 
 #[test]
 fn tms_fails_with_missing_config() -> anyhow::Result<()> {
@@ -64,6 +66,7 @@ fn tms_config() -> anyhow::Result<()> {
         bookmarks: None,
         session_configs: None,
         marks: None,
+        clone_repo_switch: Some(CloneRepoSwitchConfig::Always),
     };
 
     let mut tms = Command::cargo_bin("tms")?;
@@ -99,6 +102,8 @@ fn tms_config() -> anyhow::Result<()> {
             &picker_info_color.to_string(),
             "--picker-prompt-color",
             &picker_prompt_color.to_string(),
+            "--clone-repo-switch",
+            "Always",
         ]);
 
     tms.assert().success().code(0);


### PR DESCRIPTION
Closes https://github.com/jrmoulton/tmux-sessionizer/issues/137

No idea if my calculation of the download rate is even slightly correct tbh, but it seems about right for the speeds that I usually get.
Didn't feel like including another crate just for one progress bar, so this is just a slightly scuffed one using block characters

I've noticed the need for the new config option because I've repeatedly cloned a very large repo while developing this, and sometimes switched to another session and then it would finish cloning in the background and rip me out of what I was currently doing somewhere else.