### PR TITLE
Add config option for listing worktrees for bare repositories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2893,6 +2893,7 @@ dependencies = [
  "once_cell",
  "predicates",
  "pretty_assertions",
+ "prost",
  "ratatui",
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ nucleo = "0.5.0"
 ratatui = { version = "0.29", features = ["serde"] }
 crossterm = "0.28"
 once_cell = "1.20"
+prost = "0.14.3"
 
 [lib]
 name = "tms"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,7 +26,7 @@ use ratatui::style::Color;
 
 #[derive(Debug, Parser)]
 #[command(author, version)]
-///Scan for all git folders in specified directorires, select one and open it as a new tmux session
+///Scan for all git folders in specified directories, select one and open it as a new tmux session
 pub struct Cli {
     #[command(subcommand)]
     command: Option<CliCommand>,
@@ -120,7 +120,7 @@ pub struct ConfigArgs {
     /// Background color of the highlighted item in the picker
     picker_highlight_color: Option<Color>,
     #[arg(long, value_name = "#rrggbb")]
-    /// Text color of the hightlighted item in the picker
+    /// Text color of the highlighted item in the picker
     picker_highlight_text_color: Option<Color>,
     #[arg(long, value_name = "#rrggbb")]
     /// Color of the borders between widgets in the picker
@@ -141,6 +141,9 @@ pub struct ConfigArgs {
     /// When set to `Foreground`, the new session will only be opened in the background if the active
     /// tmux session has changed since starting the clone process (for long clone processes on larger repos)
     clone_repo_switch: Option<CloneRepoSwitchConfig>,
+    #[arg(long, value_name = "true | false")]
+    /// Enable listing of woktrees for bare repositories
+    enable_list_worktrees: Option<bool>,
 }
 
 #[derive(Debug, Args)]
@@ -434,6 +437,10 @@ fn config_command(cmd: &ConfigCommand, mut config: Config) -> Result<()> {
 
     if let Some(switch_filter_unknown) = args.switch_filter_unknown {
         config.switch_filter_unknown = Some(switch_filter_unknown.to_owned());
+    }
+
+    if let Some(enable_list_worktrees) = args.enable_list_worktrees {
+        config.list_worktrees = Some(enable_list_worktrees.to_owned());
     }
 
     if let Some(dirs) = &args.excluded_dirs {

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -54,6 +54,7 @@ pub struct Config {
     pub marks: Option<HashMap<String, String>>,
     pub clone_repo_switch: Option<CloneRepoSwitchConfig>,
     pub vcs_providers: Option<Vec<VcsProviders>>,
+    pub list_worktrees: Option<bool>,
 }
 
 pub const DEFAULT_VCS_PROVIDERS: &[VcsProviders] = &[VcsProviders::Git];
@@ -84,6 +85,7 @@ pub struct ConfigExport {
     pub marks: HashMap<String, String>,
     pub clone_repo_switch: CloneRepoSwitchConfig,
     pub vcs_providers: Vec<VcsProviders>,
+    pub list_worktrees: bool,
 }
 
 impl From<Config> for ConfigExport {
@@ -111,6 +113,7 @@ impl From<Config> for ConfigExport {
             marks: value.marks.unwrap_or_default(),
             clone_repo_switch: value.clone_repo_switch.unwrap_or_default(),
             vcs_providers: value.vcs_providers.unwrap_or(DEFAULT_VCS_PROVIDERS.into()),
+            list_worktrees: value.list_worktrees.unwrap_or_default(),
         }
     }
 }

--- a/src/repos.rs
+++ b/src/repos.rs
@@ -1,16 +1,18 @@
 use aho_corasick::{AhoCorasickBuilder, MatchKind};
 use error_stack::{report, Report, ResultExt};
-use gix::{Repository, Submodule};
+use gix::{bstr::ByteSlice, Repository, Submodule};
 use jj_lib::{
     config::StackedConfig,
     git_backend::GitBackend,
     local_working_copy::{LocalWorkingCopy, LocalWorkingCopyFactory},
+    protos::simple_workspace_store,
     repo::StoreFactories,
     settings::UserSettings,
     workspace::{WorkingCopyFactories, Workspace},
     workspace_store::{SimpleWorkspaceStore, WorkspaceStore},
 };
 use once_cell::sync::OnceCell;
+use prost::Message as _;
 use std::{
     collections::{HashMap, VecDeque},
     fs::{self},
@@ -54,6 +56,23 @@ impl Worktree for Workspace {
 
     fn path(&self) -> Result<PathBuf> {
         Ok(self.workspace_root().to_path_buf())
+    }
+
+    fn is_prunable(&self) -> bool {
+        false
+    }
+}
+
+impl Worktree for simple_workspace_store::Workspace {
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn path(&self) -> Result<PathBuf> {
+        self.path
+            .to_str()
+            .change_context(TmsError::NonUtf8Path)
+            .map(PathBuf::from)
     }
 
     fn is_prunable(&self) -> bool {
@@ -177,6 +196,28 @@ impl LazyRepoProvider {
                 Ok(repo.is_worktree())
             }
             VcsProviders::Jujutsu => Ok(self.path.join(".jj/repo").is_file()),
+        }
+    }
+
+    pub fn worktrees(&'_ self) -> Result<Vec<Box<dyn Worktree + '_>>> {
+        match self.provider {
+            VcsProviders::Git => self.resolve()?.worktrees(),
+            VcsProviders::Jujutsu => {
+                let repo_path = self.path.join(".jj/repo");
+                let store_file = repo_path.join("workspace_store/index");
+                let workspace_data = fs::read(&store_file).change_context(TmsError::IoError)?;
+
+                let workspaces_proto = jj_lib::protos::simple_workspace_store::Workspaces::decode(
+                    workspace_data.as_slice(),
+                )
+                .change_context(TmsError::IoError)?;
+                let workspaces = workspaces_proto
+                    .workspaces
+                    .into_iter()
+                    .map(|w| Box::new(w) as Box<dyn Worktree>)
+                    .collect::<Vec<_>>();
+                Ok(workspaces)
+            }
         }
     }
 }
@@ -370,6 +411,30 @@ pub fn find_repos(config: &Config) -> Result<HashMap<String, Vec<Session>>> {
                 Report::new(TmsError::GitError).attach_printable("Not a valid repository name")
             })?
             .to_string()?;
+
+        if let Some(true) = config.list_worktrees {
+            let vcs_provider_config = config
+                .vcs_providers
+                .clone()
+                .unwrap_or_else(|| DEFAULT_VCS_PROVIDERS.to_vec());
+            for worktree in repo.worktrees()?.iter() {
+                let Ok(sub) = worktree
+                    .path()
+                    .and_then(|path| LazyRepoProvider::new(&path, &vcs_provider_config))
+                else {
+                    continue;
+                };
+                let session = Session::new(
+                    format!("{}#{}", session_name, worktree.name()),
+                    SessionType::Git(sub),
+                );
+                if let Some(list) = repos.get_mut(&session.name) {
+                    list.push(session);
+                } else {
+                    repos.insert(session.name.clone(), vec![session]);
+                }
+            }
+        }
 
         let session = Session::new(session_name, SessionType::Git(repo));
         if let Some(list) = repos.get_mut(&session.name) {

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -250,6 +250,9 @@ impl Tmux {
     }
 
     pub fn set_up_tmux_env(&self, repo: &RepoProvider, repo_name: &str) -> Result<()> {
+        if repo.is_worktree() {
+            return Ok(());
+        }
         let worktrees = repo.worktrees().change_context(TmsError::GitError)?;
         let worktrees = worktrees
             .iter()

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -69,6 +69,7 @@ fn tms_config() -> anyhow::Result<()> {
         clone_repo_switch: Some(CloneRepoSwitchConfig::Always),
         vcs_providers: None,
         input_position: None,
+        list_worktrees: None,
     };
 
     let mut tms = Command::cargo_bin("tms")?;

--- a/tests/repos.rs
+++ b/tests/repos.rs
@@ -47,6 +47,39 @@ fn find_repos_includes_gitlink_project() {
 }
 
 #[test]
+fn find_repos_includes_worktrees() {
+    let dir = tempdir().unwrap();
+    let search = dir.path().join("search");
+    let project = search.join("my-project");
+    fs::create_dir_all(&project).unwrap();
+    let search = fs::canonicalize(&search).unwrap();
+    Command::new("git")
+        .args(["init", "--bare"])
+        .arg(&project)
+        .status()
+        .unwrap();
+    Command::new("git")
+        .args(["worktree", "add", "main"])
+        .current_dir(&project)
+        .status()
+        .unwrap();
+    Command::new("git")
+        .args(["worktree", "add", "test"])
+        .current_dir(&project)
+        .status()
+        .unwrap();
+    let mut config = config_searching(search, 2);
+    config.list_worktrees = Some(true);
+
+    let repos = find_repos(&config).unwrap();
+
+    assert!(repos.contains_key("my-project"));
+    assert!(repos.contains_key("my-project#main"));
+    assert!(repos.contains_key("my-project#test"));
+    assert_eq!(repos.len(), 3);
+}
+
+#[test]
 fn find_repos_excludes_linked_worktree() {
     let dir = tempdir().unwrap();
     let search = dir.path().join("search");


### PR DESCRIPTION
https://github.com/jrmoulton/tmux-sessionizer/pull/143 redone on top of latest main,
which actually means that not much was kept since quite a bit has changed since then :)

Because jj doesn't store the location of workspaces, and with the option enabled we'd be
checking workspaces of all repos, without any optimizations the existing solution was very
slow since for each repo we'd go over all configured search paths and look for jj workspaces.
There are discussions on it, so in the future jj might actually know the locations of
workspaces, and then this will become obsolete, but for now I tried to optimize it by first
gathering a list of all workspace names (these *are* known by jj), and then seeing if all of
them could be found inside of the current repo's directory (if bare). If not, we'd go back to
scanning all search paths again. (So there's probably still some room for optimizations).
But in the case of having no workspaces at all, neither of these things will be done.
I don't know if the number of repos I have is anything close to representative, so I'd be
glad for some testing and reports of how this performs :)