### PR TITLE
clone/init repo: skip search paths with depth == 0

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -678,6 +678,7 @@ fn pick_search_path(config: &Config, tmux: &Tmux) -> Result<Option<PathBuf>> {
         .ok_or(TmsError::ConfigError)
         .attach_printable("No search path configured")?
         .iter()
+        .filter(|dir| dir.depth > 0)
         .map(|dir| dir.path.to_string())
         .filter_map(|path| path.ok())
         .collect::<Vec<String>>();


### PR DESCRIPTION
If a search path is configured with depth 0, its subdirectories will not be searched, so cloning into it is pointless. The only reason to have it configured if there is a singular repository in an isolated location which should show up on the picker, and in that case offering it as an option does not make sense.