### PR TITLE
Allow scanning of non-git folders

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,58 @@
+# Plan: Implement searching for non-Git directories
+
+## Goal
+
+Modify `tmux-sessionizer` to optionally scan for all directories, not just Git repositories. This feature will be controlled by a new flag in the `config.toml` file, ensuring it's opt-in and doesn't alter the default behavior for existing users.
+
+## Step-by-step Implementation
+
+### 1. Configuration Update
+
+- **File to modify:** `src/configs.rs`
+- **Action:** Add a new boolean field to the `Config` struct.
+  - **Field name:** `search_non_git_dirs`
+  - **Type:** `bool`
+  - **Default:** `false`
+- This ensures the feature is disabled by default.
+
+- **File to modify:** `src/cli.rs`
+- **Action:** Add a new command-line argument to the `tms config` subcommand.
+  - **Argument:** `--search-non-git-dirs <true|false>`
+  - This will allow users to enable or disable the feature from the CLI, which will update the `config.toml` file.
+
+### 2. Core Logic Modification
+
+- **File to modify:** `src/repos.rs`
+- **Action:** Update the directory scanning logic (likely in a function like `find_repos` or similar).
+  - The current implementation probably iterates through directories and checks for the existence of a `.git` subdirectory.
+  - The logic will be wrapped in a conditional check:
+    - **If `config.search_non_git_dirs` is `false`:** Keep the existing behavior (search for Git repositories only).
+    - **If `config.search_non_git_dirs` is `true`:** Modify the search to include all directories that are not otherwise excluded by the user's configuration (`excluded_dirs`). The search must continue to respect the `max_depths` setting.
+
+### 3. Display and Integration
+
+- **File to consider:** `src/session.rs` (or wherever the `Repo` / `Project` struct is defined)
+- **Action:** Ensure that the struct used to represent a selectable item can handle non-Git directories gracefully.
+  - Plain directories won't have Git-specific information (like worktrees or a `.git` folder). The existing struct should be reviewed to ensure this doesn't cause issues. It's expected that functions for Git-specific features (like worktree discovery) will simply do nothing for these new directory types.
+  - No changes are anticipated for the fuzzy picker display. It should display the directory name, which is the desired behavior.
+
+### 4. Testing
+
+- **File to modify:** `tests/cli.rs`
+- **Action:** Add new integration tests to validate the feature.
+  - **Test Case 1 (Flag Off):**
+    - Create a temporary directory structure containing both Git and non-Git subdirectories.
+    - Run the scanner with `search_non_git_dirs` set to `false`.
+    - Assert that only the Git repositories are found.
+  - **Test Case 2 (Flag On):**
+    - Use the same directory structure.
+    - Run the scanner with `search_non_git_dirs` set to `true`.
+    - Assert that all directories (both Git and non-Git) are found, respecting any exclusion rules.
+
+### 5. Documentation
+
+- **File to modify:** `README.md`
+- **Action:** Update the documentation to reflect the new feature.
+  - Explain the `search_non_git_dirs` option in the "Configuring defaults" section.
+  - Briefly describe the new capability in the main "Usage" section.
+- The help text for the `tms config` command will be automatically updated by the changes in `src/cli.rs`.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Tmux Sessionizer is a tmux session manager that is based on ThePrimeagen's
 but is opinionated and personalized to my specific tmux workflow. And it's awesome. Git worktrees
 are automatically opened as new windows, specific directories can be excluded, a default session can
 be set, killing a session jumps you to a default, and it is a goal to handle more edge case
-scenarios.
+scenarios. By default, tms searches for git repositories, but it can be configured to search for any
+directory.
 
 Tmux has keybindings built-in to allow you to switch between sessions. By default, these are
 `leader-(` and `leader-)`
@@ -116,6 +117,8 @@ Options:
           Search submodules for submodules [possible values: true, false]
       --switch-filter-unknown <true | false>
           Only include sessions from search paths in the switcher [possible values: true, false]
+      --search-non-git-dirs <true | false>
+          Also search for non-git directories [possible values: true, false]
   -d, --max-depths <max depth>...
           The maximum depth to traverse when searching for repositories in search paths, length should match the number of search paths if specified (defaults to 10)
       --picker-highlight-color <#rrggbb>

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -41,6 +41,7 @@ pub struct Config {
     pub search_submodules: Option<bool>,
     pub recursive_submodules: Option<bool>,
     pub switch_filter_unknown: Option<bool>,
+    pub search_non_git_dirs: Option<bool>,
     pub session_sort_order: Option<SessionSortOrderConfig>,
     pub excluded_dirs: Option<Vec<String>>,
     pub search_paths: Option<Vec<String>>, // old format, deprecated
@@ -73,6 +74,7 @@ pub struct ConfigExport {
     pub search_submodules: bool,
     pub recursive_submodules: bool,
     pub switch_filter_unknown: bool,
+    pub search_non_git_dirs: bool,
     pub session_sort_order: SessionSortOrderConfig,
     pub excluded_dirs: Vec<String>,
     pub search_dirs: Vec<SearchDirectory>,
@@ -94,6 +96,7 @@ impl From<Config> for ConfigExport {
             search_submodules: value.search_submodules.unwrap_or_default(),
             recursive_submodules: value.recursive_submodules.unwrap_or_default(),
             switch_filter_unknown: value.switch_filter_unknown.unwrap_or_default(),
+            search_non_git_dirs: value.search_non_git_dirs.unwrap_or_default(),
             session_sort_order: value.session_sort_order.unwrap_or_default(),
             excluded_dirs: value.excluded_dirs.unwrap_or_default(),
             search_dirs: value.search_dirs.unwrap_or_default(),

--- a/src/marks.rs
+++ b/src/marks.rs
@@ -153,7 +153,7 @@ fn path_to_session(path: &String) -> Result<Session> {
         .file_name()
         .expect("The file name doesn't end in `..`")
         .to_string()?;
-    let session = Session::new(session_name, crate::session::SessionType::Bookmark(path));
+    let session = Session::new(session_name, crate::session::SessionType::Path(path));
     Ok(session)
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -21,7 +21,7 @@ pub struct Session {
 
 pub enum SessionType {
     Git(RepoProvider),
-    Bookmark(PathBuf),
+    Path(PathBuf),
 }
 
 impl Session {
@@ -33,14 +33,14 @@ impl Session {
         match &self.session_type {
             SessionType::Git(repo) if repo.is_bare() => repo.path(),
             SessionType::Git(repo) => repo.path().parent().unwrap(),
-            SessionType::Bookmark(path) => path,
+            SessionType::Path(path) => path,
         }
     }
 
     pub fn switch_to(&self, tmux: &Tmux, config: &Config) -> Result<()> {
         match &self.session_type {
             SessionType::Git(repo) => self.switch_to_repo_session(repo, tmux, config),
-            SessionType::Bookmark(path) => self.switch_to_bookmark_session(tmux, path, config),
+            SessionType::Path(path) => self.switch_to_path_session(tmux, path, config),
         }
     }
 
@@ -72,7 +72,7 @@ impl Session {
         Ok(())
     }
 
-    fn switch_to_bookmark_session(&self, tmux: &Tmux, path: &Path, config: &Config) -> Result<()> {
+    fn switch_to_path_session(&self, tmux: &Tmux, path: &Path, config: &Config) -> Result<()> {
         let session_name = self.name.replace('.', "_");
 
         if !tmux.session_exists(&session_name) {
@@ -225,7 +225,7 @@ fn append_bookmarks(
             .file_name()
             .expect("The file name doesn't end in `..`")
             .to_string()?;
-        let session = Session::new(session_name, SessionType::Bookmark(path));
+        let session = Session::new(session_name, SessionType::Path(path));
         if let Some(list) = sessions.get_mut(&session.name) {
             list.push(session);
         } else {
@@ -245,15 +245,15 @@ mod tests {
         let mut test_sessions = vec![
             Session::new(
                 "test".into(),
-                SessionType::Bookmark("/search/path/to/proj1/test".into()),
+                SessionType::Path("/search/path/to/proj1/test".into()),
             ),
             Session::new(
                 "test".into(),
-                SessionType::Bookmark("/search/path/to/proj2/test".into()),
+                SessionType::Path("/search/path/to/proj2/test".into()),
             ),
             Session::new(
                 "test".into(),
-                SessionType::Bookmark("/other/path/to/projects/proj2/test".into()),
+                SessionType::Path("/other/path/to/projects/proj2/test".into()),
             ),
         ];
 


### PR DESCRIPTION
The original tmux-sessionizer script by the-primeagen searched all subfolders, not only ones that are git repositories. This PR adds a config flag search_non_git_dirs to allow search of all sub directories. Also flags are added for tms to allow switching between these two modes for any search. So it's possible to for example have key bindings for both.
The flags are:
```
      --search-non-git-dirs  Search for non-git directories, overriding config
      --search-git-dirs      Search only for git directories, overriding config
```

