### PR TITLE
feat: unify projects and running sessions in default picker

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,58 @@
+# Plan: Implement searching for non-Git directories
+
+## Goal
+
+Modify `tmux-sessionizer` to optionally scan for all directories, not just Git repositories. This feature will be controlled by a new flag in the `config.toml` file, ensuring it's opt-in and doesn't alter the default behavior for existing users.
+
+## Step-by-step Implementation
+
+### 1. Configuration Update
+
+- **File to modify:** `src/configs.rs`
+- **Action:** Add a new boolean field to the `Config` struct.
+  - **Field name:** `search_non_git_dirs`
+  - **Type:** `bool`
+  - **Default:** `false`
+- This ensures the feature is disabled by default.
+
+- **File to modify:** `src/cli.rs`
+- **Action:** Add a new command-line argument to the `tms config` subcommand.
+  - **Argument:** `--search-non-git-dirs <true|false>`
+  - This will allow users to enable or disable the feature from the CLI, which will update the `config.toml` file.
+
+### 2. Core Logic Modification
+
+- **File to modify:** `src/repos.rs`
+- **Action:** Update the directory scanning logic (likely in a function like `find_repos` or similar).
+  - The current implementation probably iterates through directories and checks for the existence of a `.git` subdirectory.
+  - The logic will be wrapped in a conditional check:
+    - **If `config.search_non_git_dirs` is `false`:** Keep the existing behavior (search for Git repositories only).
+    - **If `config.search_non_git_dirs` is `true`:** Modify the search to include all directories that are not otherwise excluded by the user's configuration (`excluded_dirs`). The search must continue to respect the `max_depths` setting.
+
+### 3. Display and Integration
+
+- **File to consider:** `src/session.rs` (or wherever the `Repo` / `Project` struct is defined)
+- **Action:** Ensure that the struct used to represent a selectable item can handle non-Git directories gracefully.
+  - Plain directories won't have Git-specific information (like worktrees or a `.git` folder). The existing struct should be reviewed to ensure this doesn't cause issues. It's expected that functions for Git-specific features (like worktree discovery) will simply do nothing for these new directory types.
+  - No changes are anticipated for the fuzzy picker display. It should display the directory name, which is the desired behavior.
+
+### 4. Testing
+
+- **File to modify:** `tests/cli.rs`
+- **Action:** Add new integration tests to validate the feature.
+  - **Test Case 1 (Flag Off):**
+    - Create a temporary directory structure containing both Git and non-Git subdirectories.
+    - Run the scanner with `search_non_git_dirs` set to `false`.
+    - Assert that only the Git repositories are found.
+  - **Test Case 2 (Flag On):**
+    - Use the same directory structure.
+    - Run the scanner with `search_non_git_dirs` set to `true`.
+    - Assert that all directories (both Git and non-Git) are found, respecting any exclusion rules.
+
+### 5. Documentation
+
+- **File to modify:** `README.md`
+- **Action:** Update the documentation to reflect the new feature.
+  - Explain the `search_non_git_dirs` option in the "Configuring defaults" section.
+  - Briefly describe the new capability in the main "Usage" section.
+- The help text for the `tms config` command will be automatically updated by the changes in `src/cli.rs`.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Tmux Sessionizer is a tmux session manager that is based on ThePrimeagen's
 but is opinionated and personalized to my specific tmux workflow. And it's awesome. Git worktrees
 are automatically opened as new windows, specific directories can be excluded, a default session can
 be set, killing a session jumps you to a default, and it is a goal to handle more edge case
-scenarios.
+scenarios. By default, tms searches for git repositories, but it can be configured to search for any
+directory.
 
 Tmux has keybindings built-in to allow you to switch between sessions. By default, these are
 `leader-(` and `leader-)`
@@ -116,6 +117,8 @@ Options:
           Search submodules for submodules [possible values: true, false]
       --switch-filter-unknown <true | false>
           Only include sessions from search paths in the switcher [possible values: true, false]
+      --search-non-git-dirs <true | false>
+          Also search for non-git directories [possible values: true, false]
   -d, --max-depths <max depth>...
           The maximum depth to traverse when searching for repositories in search paths, length should match the number of search paths if specified (defaults to 10)
       --picker-highlight-color <#rrggbb>

--- a/plans/unify_sessions_and_projects.md
+++ b/plans/unify_sessions_and_projects.md
@@ -1,0 +1,78 @@
+# Plan: Unify Projects and Running Sessions in the Default Picker
+
+## Goal
+
+Modify the default `tms` command to display a single, unified list of available projects (from disk) and currently running tmux sessions. This list will be deduplicated, so a project that is already running as a session appears only once, marked as "running". This provides a seamless experience for both creating new sessions and switching to existing ones from one interface.
+
+## The `PickerItem` Approach
+
+Instead of forcing tmux sessions into a `Repo` object, we will introduce a new, unified enum `PickerItem` that can cleanly represent all possible selectable items.
+
+```rust
+// In a new file, e.g., `src/picker_item.rs`
+pub enum PickerItem {
+    Project(Session),
+    TmuxSession(String),
+}
+
+impl PickerItem {
+    pub fn display_name(&self) -> String {
+        // ... logic to get name from Session or the TmuxSession String
+    }
+
+    pub fn is_running(&self, running_sessions: &HashSet<String>) -> bool {
+        // ... logic to check if the item is in the set of running sessions
+    }
+}
+```
+
+## Step-by-step Implementation
+
+### 1. Configuration
+
+-   **File to modify:** `src/configs.rs`
+-   **Action:** Add a new `search_tmux_sessions: Option<bool>` field to the `Config` and `ConfigExport` structs. This will be `true` by default to enable the new unified view.
+-   **File to modify:** `src/cli.rs`
+-   **Action:** Add a `--search-tmux-sessions <true|false>` command-line argument to the `tms config` subcommand to allow users to toggle this feature.
+
+### 2. Core Logic Modification
+
+-   **File to modify:** `src/tmux.rs`
+-   **Action:** Create a new public function, `get_running_sessions()`, that executes `tmux list-sessions` and returns a `Result<HashSet<String>>` containing the names of all active sessions.
+
+-   **File to modify:** `src/repos.rs`
+-   **Action:** Refactor the `find_repos` function (or create a new one, e.g., `get_picker_items`).
+    1.  It will first call `tmux::get_running_sessions()` to get all active session names.
+    2.  It will then scan the filesystem for projects (`Session` objects) as it does now.
+    3.  It will iterate through the found projects, creating a `PickerItem::Project(session)` for each. It will use the set of running sessions to mark projects that are already active, preventing duplicates.
+    4.  Finally, it will iterate through the remaining running sessions (those that did not correspond to a found project) and create a `PickerItem::TmuxSession(name)` for each.
+    5.  The function will return a `Vec<PickerItem>`.
+
+### 3. Picker Integration
+
+-   **File to create:** `src/picker_item.rs`
+-   **Action:** Define the `PickerItem` enum and its associated methods as described above. It will need a method to provide the string for the fuzzy finder.
+
+-   **Files to modify:** `src/picker/mod.rs` and `src/lib.rs`
+-   **Action:** The current picker logic in `get_single_selection` and the `Picker` struct is hardcoded to work with `String`. This needs to be adapted to work with `Vec<PickerItem>`.
+    -   The `Picker` will be initialized with `Vec<PickerItem>`.
+    -   It will use the `display_name()` method of each `PickerItem` to populate the fuzzy finder list.
+    -   The `run` method will now return `Result<Option<PickerItem>>`.
+
+### 4. Main Application Logic
+
+-   **File to modify:** `src/main.rs`
+-   **Action:**
+    1.  Update the main execution flow to call the new `get_picker_items` function.
+    2.  Pass the resulting `Vec<PickerItem>` to the `get_single_selection` function.
+    3.  Inspect the returned `PickerItem`.
+        -   If the item was a `PickerItem::Project`, use the inner `Session` to create a new tmux session as is currently done.
+        -   If the item was a `PickerItem::TmuxSession` (or a project that was already running), execute the tmux `switch-client` command to attach to that session.
+
+### 5. Testing
+
+-   **File to modify:** `tests/cli.rs`
+-   **Action:** Add new integration tests.
+    -   **Test Unified List:** Create mock projects and mock running tmux sessions. Run `tms` and assert that the picker receives a correctly unified and deduplicated list of items.
+    -   **Test Feature Flag:** Test that setting `search_tmux_sessions = false` results in only projects being shown.
+    -   **Test Actions:** Mock the picker's selection and assert that selecting a running session results in a `switch-client` command, while selecting a non-running project results in a `new-session` command.

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -41,6 +41,7 @@ pub struct Config {
     pub search_submodules: Option<bool>,
     pub recursive_submodules: Option<bool>,
     pub switch_filter_unknown: Option<bool>,
+    pub search_non_git_dirs: Option<bool>,
     pub session_sort_order: Option<SessionSortOrderConfig>,
     pub excluded_dirs: Option<Vec<String>>,
     pub search_paths: Option<Vec<String>>, // old format, deprecated
@@ -73,6 +74,7 @@ pub struct ConfigExport {
     pub search_submodules: bool,
     pub recursive_submodules: bool,
     pub switch_filter_unknown: bool,
+    pub search_non_git_dirs: bool,
     pub session_sort_order: SessionSortOrderConfig,
     pub excluded_dirs: Vec<String>,
     pub search_dirs: Vec<SearchDirectory>,
@@ -94,6 +96,7 @@ impl From<Config> for ConfigExport {
             search_submodules: value.search_submodules.unwrap_or_default(),
             recursive_submodules: value.recursive_submodules.unwrap_or_default(),
             switch_filter_unknown: value.switch_filter_unknown.unwrap_or_default(),
+            search_non_git_dirs: value.search_non_git_dirs.unwrap_or_default(),
             session_sort_order: value.session_sort_order.unwrap_or_default(),
             excluded_dirs: value.excluded_dirs.unwrap_or_default(),
             search_dirs: value.search_dirs.unwrap_or_default(),

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -42,6 +42,7 @@ pub struct Config {
     pub recursive_submodules: Option<bool>,
     pub switch_filter_unknown: Option<bool>,
     pub search_non_git_dirs: Option<bool>,
+    pub search_tmux_sessions: Option<bool>,
     pub session_sort_order: Option<SessionSortOrderConfig>,
     pub excluded_dirs: Option<Vec<String>>,
     pub search_paths: Option<Vec<String>>, // old format, deprecated
@@ -75,6 +76,7 @@ pub struct ConfigExport {
     pub recursive_submodules: bool,
     pub switch_filter_unknown: bool,
     pub search_non_git_dirs: bool,
+    pub search_tmux_sessions: bool,
     pub session_sort_order: SessionSortOrderConfig,
     pub excluded_dirs: Vec<String>,
     pub search_dirs: Vec<SearchDirectory>,
@@ -97,6 +99,7 @@ impl From<Config> for ConfigExport {
             recursive_submodules: value.recursive_submodules.unwrap_or_default(),
             switch_filter_unknown: value.switch_filter_unknown.unwrap_or_default(),
             search_non_git_dirs: value.search_non_git_dirs.unwrap_or_default(),
+            search_tmux_sessions: value.search_tmux_sessions.unwrap_or(true),
             session_sort_order: value.session_sort_order.unwrap_or_default(),
             excluded_dirs: value.excluded_dirs.unwrap_or_default(),
             search_dirs: value.search_dirs.unwrap_or_default(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,10 @@ use std::process;
 
 use crate::{
     error::{Result, TmsError},
-    picker::{Picker, Preview},
+    picker::{Picker, PickerItem, Preview},
     tmux::Tmux,
 };
+use std::collections::HashSet;
 
 pub fn execute_command(command: &str, args: Vec<String>) -> process::Output {
     process::Command::new(command)
@@ -27,13 +28,15 @@ pub fn execute_command(command: &str, args: Vec<String>) -> process::Output {
 }
 
 pub fn get_single_selection(
-    list: &[String],
+    list: Vec<PickerItem>,
+    running_sessions: HashSet<String>,
     preview: Option<Preview>,
     config: &Config,
     tmux: &Tmux,
-) -> Result<Option<String>> {
+) -> Result<Option<PickerItem>> {
     let mut picker = Picker::new(
         list,
+        running_sessions,
         preview,
         config.shortcuts.as_ref(),
         config.input_position.unwrap_or_default(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,13 +2,17 @@ use std::env;
 
 use clap::{CommandFactory, Parser};
 use clap_complete::CompleteEnv;
-use error_stack::Report;
+use error_stack::{Report, ResultExt};
 
 use tms::{
     cli::{Cli, SubCommandGiven},
-    error::{Result, Suggestion},
+    configs::Config,
+    dirty_paths::DirtyUtf8Path,
+    error::{Result, Suggestion, TmsError},
     get_single_selection,
-    session::{create_sessions, SessionContainer},
+    picker::PickerItem,
+    repos::{get_picker_items, RepoProvider},
+    session::{Session, SessionType},
     tmux::Tmux,
 };
 
@@ -45,19 +49,90 @@ fn main() -> Result<()> {
         SubCommandGiven::No(config) => config, // continue
     };
 
-    let sessions = create_sessions(&config)?;
-    let session_strings = sessions.list();
+    let picker_items = get_picker_items(&config, &tmux)?;
+    let running_sessions = tmux.get_running_sessions()?;
 
-    let selected_str =
-        if let Some(str) = get_single_selection(&session_strings, None, &config, &tmux)? {
-            str
+    let selected_item =
+        if let Some(item) = get_single_selection(picker_items, running_sessions.clone(), None, &config, &tmux)? {
+            item
         } else {
             return Ok(());
         };
 
-    if let Some(session) = sessions.find_session(&selected_str) {
-        session.switch_to(&tmux, &config)?;
+    match selected_item {
+        PickerItem::Project { name, path } => {
+            if running_sessions.contains(&name) {
+                tmux.switch_client(&name);
+            } else {
+                let session_type = if path.join(".git").exists() {
+                    SessionType::Git
+                } else {
+                    SessionType::Path
+                };
+                let session = Session::new(name, path, session_type);
+                switch_to_session(&session, &tmux, &config)?;
+            }
+        }
+        PickerItem::TmuxSession(session_name) => {
+            tmux.switch_client(&session_name);
+        }
     }
+
+    Ok(())
+}
+
+fn switch_to_session(session: &Session, tmux: &Tmux, config: &Config) -> Result<()> {
+    match &session.session_type {
+        SessionType::Git => {
+            let repo = RepoProvider::open(&session.path, config)?;
+            switch_to_repo_session(session, &repo, tmux, config)
+        }
+        SessionType::Path => switch_to_path_session(session, tmux, &session.path, config),
+    }
+}
+
+fn switch_to_repo_session(
+    session: &Session,
+    repo: &RepoProvider,
+    tmux: &Tmux,
+    config: &Config,
+) -> Result<()> {
+    let path = if repo.is_bare() {
+        repo.path().to_path_buf().to_string()?
+    } else {
+        repo.work_dir()
+            .expect("bare repositories should all have parent directories")
+            .canonicalize()
+            .change_context(TmsError::IoError)?
+            .to_string()?
+    };
+    let session_name = session.name.replace('.', "_");
+
+    if !tmux.session_exists(&session_name) {
+        tmux.new_session(Some(&session_name), Some(&path));
+        tmux.set_up_tmux_env(repo, &session_name, config)?;
+        tmux.run_session_create_script(&session.path, &session_name, config)?;
+    }
+
+    tmux.switch_to_session(&session_name);
+
+    Ok(())
+}
+
+fn switch_to_path_session(
+    session: &Session,
+    tmux: &Tmux,
+    path: &std::path::Path,
+    config: &Config,
+) -> Result<()> {
+    let session_name = session.name.replace('.', "_");
+
+    if !tmux.session_exists(&session_name) {
+        tmux.new_session(Some(&session_name), path.to_str());
+        tmux.run_session_create_script(path, &session_name, config)?;
+    }
+
+    tmux.switch_to_session(&session_name);
 
     Ok(())
 }

--- a/src/marks.rs
+++ b/src/marks.rs
@@ -153,7 +153,7 @@ fn path_to_session(path: &String) -> Result<Session> {
         .file_name()
         .expect("The file name doesn't end in `..`")
         .to_string()?;
-    let session = Session::new(session_name, crate::session::SessionType::Bookmark(path));
+    let session = Session::new(session_name, crate::session::SessionType::Path(path));
     Ok(session)
 }
 

--- a/src/marks.rs
+++ b/src/marks.rs
@@ -86,7 +86,7 @@ pub fn marks_command(args: &MarksCommand, config: Config, tmux: &Tmux) -> Result
 fn list(config: Config) -> Result<()> {
     let items = get_marks(&config).unwrap_or_default();
     items.iter().for_each(|(index, session)| {
-        println!("{index}: {} ({})", session.name, session.path().display());
+        println!("{index}: {} ({})", session.name, session.path.display());
     });
     Ok(())
 }
@@ -137,7 +137,16 @@ fn open(index: usize, config: &Config, tmux: &Tmux) -> Result<()> {
 
     let session = path_to_session(path)?;
 
-    session.switch_to(tmux, config)
+    let session_name = session.name.replace('.', "_");
+
+    if !tmux.session_exists(&session_name) {
+        tmux.new_session(Some(&session_name), session.path.to_str());
+        tmux.run_session_create_script(&session.path, &session_name, config)?;
+    }
+
+    tmux.switch_to_session(&session_name);
+
+    Ok(())
 }
 
 fn path_to_session(path: &String) -> Result<Session> {
@@ -153,7 +162,11 @@ fn path_to_session(path: &String) -> Result<Session> {
         .file_name()
         .expect("The file name doesn't end in `..`")
         .to_string()?;
-    let session = Session::new(session_name, crate::session::SessionType::Path(path));
+    let session = Session::new(
+        session_name,
+        path.clone(),
+        crate::session::SessionType::Path,
+    );
     Ok(session)
 }
 

--- a/src/picker/item.rs
+++ b/src/picker/item.rs
@@ -1,0 +1,29 @@
+use std::{collections::HashSet, path::PathBuf};
+
+#[derive(Clone)]
+pub enum PickerItem {
+    Project { name: String, path: PathBuf },
+    TmuxSession(String),
+}
+
+impl PickerItem {
+    pub fn name(&self) -> &str {
+        match self {
+            PickerItem::Project { name, .. } => name,
+            PickerItem::TmuxSession(name) => name,
+        }
+    }
+
+    pub fn display_name(&self, running_sessions: &HashSet<String>) -> String {
+        let name = self.name();
+        if running_sessions.contains(name) {
+            format!("* {}", name)
+        } else {
+            name.to_string()
+        }
+    }
+
+    pub fn is_running(&self, running_sessions: &HashSet<String>) -> bool {
+        running_sessions.contains(self.name())
+    }
+}

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,88 +1,34 @@
 use std::{
     collections::HashMap,
-    path::{Path, PathBuf},
+    path::PathBuf,
 };
-
-use error_stack::ResultExt;
 
 use crate::{
     configs::Config,
-    dirty_paths::DirtyUtf8Path,
-    error::TmsError,
-    repos::{find_repos, find_submodules, RepoProvider},
-    tmux::Tmux,
+    repos::{find_submodules, RepoProvider},
     Result,
 };
 
+#[derive(Clone)]
 pub struct Session {
     pub name: String,
+    pub path: PathBuf,
     pub session_type: SessionType,
 }
 
+#[derive(Clone)]
 pub enum SessionType {
-    Git(RepoProvider),
-    Path(PathBuf),
+    Git,
+    Path,
 }
 
 impl Session {
-    pub fn new(name: String, session_type: SessionType) -> Self {
-        Session { name, session_type }
-    }
-
-    pub fn path(&self) -> &Path {
-        match &self.session_type {
-            SessionType::Git(repo) if repo.is_bare() => repo.path(),
-            SessionType::Git(repo) => repo.path().parent().unwrap(),
-            SessionType::Path(path) => path,
+    pub fn new(name: String, path: PathBuf, session_type: SessionType) -> Self {
+        Session {
+            name,
+            path,
+            session_type,
         }
-    }
-
-    pub fn switch_to(&self, tmux: &Tmux, config: &Config) -> Result<()> {
-        match &self.session_type {
-            SessionType::Git(repo) => self.switch_to_repo_session(repo, tmux, config),
-            SessionType::Path(path) => self.switch_to_path_session(tmux, path, config),
-        }
-    }
-
-    fn switch_to_repo_session(
-        &self,
-        repo: &RepoProvider,
-        tmux: &Tmux,
-        config: &Config,
-    ) -> Result<()> {
-        let path = if repo.is_bare() {
-            repo.path().to_path_buf().to_string()?
-        } else {
-            repo.work_dir()
-                .expect("bare repositories should all have parent directories")
-                .canonicalize()
-                .change_context(TmsError::IoError)?
-                .to_string()?
-        };
-        let session_name = self.name.replace('.', "_");
-
-        if !tmux.session_exists(&session_name) {
-            tmux.new_session(Some(&session_name), Some(&path));
-            tmux.set_up_tmux_env(repo, &session_name, config)?;
-            tmux.run_session_create_script(self.path(), &session_name, config)?;
-        }
-
-        tmux.switch_to_session(&session_name);
-
-        Ok(())
-    }
-
-    fn switch_to_path_session(&self, tmux: &Tmux, path: &Path, config: &Config) -> Result<()> {
-        let session_name = self.name.replace('.', "_");
-
-        if !tmux.session_exists(&session_name) {
-            tmux.new_session(Some(&session_name), path.to_str());
-            tmux.run_session_create_script(path, &session_name, config)?;
-        }
-
-        tmux.switch_to_session(&session_name);
-
-        Ok(())
     }
 }
 
@@ -109,19 +55,10 @@ impl SessionContainer for HashMap<String, Session> {
     }
 }
 
-pub fn create_sessions(config: &Config) -> Result<impl SessionContainer> {
-    let mut sessions = find_repos(config)?;
-    sessions = append_bookmarks(config, sessions)?;
-
-    let sessions = generate_session_container(sessions, config)?;
-
-    Ok(sessions)
-}
-
-fn generate_session_container(
+pub fn generate_session_container(
     mut sessions: HashMap<String, Vec<Session>>,
     config: &Config,
-) -> Result<impl SessionContainer> {
+) -> Result<HashMap<String, Session>> {
     let mut ret = HashMap::new();
 
     for list in sessions.values_mut() {
@@ -146,14 +83,16 @@ fn insert_session(
     config: &Config,
 ) -> Result<()> {
     let visible_name = if config.display_full_path == Some(true) {
-        session.path().display().to_string()
+        session.path.display().to_string()
     } else {
         session.name.clone()
     };
-    if let SessionType::Git(repo) = &session.session_type {
+    if let SessionType::Git = &session.session_type {
         if config.search_submodules == Some(true) {
-            if let Ok(Some(submodules)) = repo.submodules() {
-                find_submodules(submodules, &visible_name, sessions, config)?;
+            if let Ok(repo) = RepoProvider::open(&session.path, config) {
+                if let Ok(Some(submodules)) = repo.submodules() {
+                    find_submodules(submodules, &visible_name, sessions, config)?;
+                }
             }
         }
     }
@@ -166,14 +105,14 @@ fn deduplicate_sessions(duplicate_sessions: &mut Vec<Session>) -> Vec<Session> {
     let mut deduplicated = Vec::new();
     while let Some(current_session) = duplicate_sessions.pop() {
         let mut equal = true;
-        let current_path = current_session.path();
+        let current_path = &current_session.path;
         let mut current_depth = 1;
 
         while equal {
             equal = false;
             if let Some(current_str) = current_path.iter().rev().nth(current_depth) {
                 for session in &mut *duplicate_sessions {
-                    if let Some(str) = session.path().iter().rev().nth(current_depth) {
+                    if let Some(str) = session.path.iter().rev().nth(current_depth) {
                         if str == current_str {
                             current_depth += 1;
                             equal = true;
@@ -191,7 +130,7 @@ fn deduplicate_sessions(duplicate_sessions: &mut Vec<Session>) -> Vec<Session> {
     for session in &mut deduplicated {
         session.name = {
             let mut count = depth + 1;
-            let mut iterator = session.path().iter().rev();
+            let mut iterator = session.path.iter().rev();
             let mut str = String::new();
 
             while count > 0 {
@@ -214,28 +153,6 @@ fn deduplicate_sessions(duplicate_sessions: &mut Vec<Session>) -> Vec<Session> {
     deduplicated
 }
 
-fn append_bookmarks(
-    config: &Config,
-    mut sessions: HashMap<String, Vec<Session>>,
-) -> Result<HashMap<String, Vec<Session>>> {
-    let bookmarks = config.bookmark_paths();
-
-    for path in bookmarks {
-        let session_name = path
-            .file_name()
-            .expect("The file name doesn't end in `..`")
-            .to_string()?;
-        let session = Session::new(session_name, SessionType::Path(path));
-        if let Some(list) = sessions.get_mut(&session.name) {
-            list.push(session);
-        } else {
-            sessions.insert(session.name.clone(), vec![session]);
-        }
-    }
-
-    Ok(sessions)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -245,15 +162,18 @@ mod tests {
         let mut test_sessions = vec![
             Session::new(
                 "test".into(),
-                SessionType::Path("/search/path/to/proj1/test".into()),
+                "/search/path/to/proj1/test".into(),
+                SessionType::Path,
             ),
             Session::new(
                 "test".into(),
-                SessionType::Path("/search/path/to/proj2/test".into()),
+                "/search/path/to/proj2/test".into(),
+                SessionType::Path,
             ),
             Session::new(
                 "test".into(),
-                SessionType::Path("/other/path/to/projects/proj2/test".into()),
+                "/other/path/to/projects/proj2/test".into(),
+                SessionType::Path,
             ),
         ];
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -21,7 +21,7 @@ pub struct Session {
 
 pub enum SessionType {
     Git(RepoProvider),
-    Bookmark(PathBuf),
+    Path(PathBuf),
 }
 
 impl Session {
@@ -33,14 +33,14 @@ impl Session {
         match &self.session_type {
             SessionType::Git(repo) if repo.is_bare() => repo.path(),
             SessionType::Git(repo) => repo.path().parent().unwrap(),
-            SessionType::Bookmark(path) => path,
+            SessionType::Path(path) => path,
         }
     }
 
     pub fn switch_to(&self, tmux: &Tmux, config: &Config) -> Result<()> {
         match &self.session_type {
             SessionType::Git(repo) => self.switch_to_repo_session(repo, tmux, config),
-            SessionType::Bookmark(path) => self.switch_to_bookmark_session(tmux, path, config),
+            SessionType::Path(path) => self.switch_to_path_session(tmux, path, config),
         }
     }
 
@@ -72,7 +72,7 @@ impl Session {
         Ok(())
     }
 
-    fn switch_to_bookmark_session(&self, tmux: &Tmux, path: &Path, config: &Config) -> Result<()> {
+    fn switch_to_path_session(&self, tmux: &Tmux, path: &Path, config: &Config) -> Result<()> {
         let session_name = self.name.replace('.', "_");
 
         if !tmux.session_exists(&session_name) {
@@ -225,7 +225,7 @@ fn append_bookmarks(
             .file_name()
             .expect("The file name doesn't end in `..`")
             .to_string()?;
-        let session = Session::new(session_name, SessionType::Bookmark(path));
+        let session = Session::new(session_name, SessionType::Path(path));
         if let Some(list) = sessions.get_mut(&session.name) {
             list.push(session);
         } else {
@@ -245,15 +245,15 @@ mod tests {
         let mut test_sessions = vec![
             Session::new(
                 "test".into(),
-                SessionType::Bookmark("/search/path/to/proj1/test".into()),
+                SessionType::Path("/search/path/to/proj1/test".into()),
             ),
             Session::new(
                 "test".into(),
-                SessionType::Bookmark("/search/path/to/proj2/test".into()),
+                SessionType::Path("/search/path/to/proj2/test".into()),
             ),
             Session::new(
                 "test".into(),
-                SessionType::Bookmark("/other/path/to/projects/proj2/test".into()),
+                SessionType::Path("/other/path/to/projects/proj2/test".into()),
             ),
         ];
 

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -1,4 +1,4 @@
-use std::{env, os::unix::process::CommandExt, path::Path, process};
+use std::{collections::HashSet, env, os::unix::process::CommandExt, path::Path, process};
 
 use error_stack::ResultExt;
 
@@ -74,6 +74,15 @@ impl Tmux {
     pub fn list_sessions(&self, format: &str) -> String {
         let output = self.execute_tmux_command(&["list-sessions", "-F", format]);
         Tmux::stdout_to_string(output)
+    }
+
+    pub fn get_running_sessions(&self) -> Result<HashSet<String>> {
+        let output = self.list_sessions("#S");
+        let sessions = output
+            .lines()
+            .map(|s| s.trim().to_string())
+            .collect::<HashSet<String>>();
+        Ok(sessions)
     }
 
     pub fn current_session(&self, format: &str) -> String {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -48,6 +48,7 @@ fn tms_config() -> anyhow::Result<()> {
         recursive_submodules: Some(false),
         switch_filter_unknown: Some(false),
         search_non_git_dirs: Some(false),
+        search_tmux_sessions: Some(true),
         session_sort_order: Some(SessionSortOrderConfig::Alphabetical),
         excluded_dirs: Some(vec![excluded_dir.clone()]),
         search_paths: None,
@@ -93,6 +94,8 @@ fn tms_config() -> anyhow::Result<()> {
             "false",
             "--search-non-git-dirs",
             "false",
+            "--search-tmux-sessions",
+            "true",
             "--session-sort-order",
             "Alphabetical",
             "--excluded",
@@ -151,7 +154,7 @@ fn tms_list_dirs_without_non_git_dirs() -> anyhow::Result<()> {
 
     let mut tms = Command::cargo_bin("tms")?;
     tms.env("TMS_CONFIG_FILE", &config_file_path);
-    tms.arg("--just-print"); // a fake argument to just print the list and not launch fzf
+    tms.arg("--just-print");
     let output = tms.assert().success().get_output().stdout.clone();
     let output = String::from_utf8(output)?;
 
@@ -189,7 +192,7 @@ fn tms_list_dirs_with_non_git_dirs() -> anyhow::Result<()> {
 
     let mut tms = Command::cargo_bin("tms")?;
     tms.env("TMS_CONFIG_FILE", &config_file_path);
-    tms.arg("--just-print"); // a fake argument to just print the list and not launch fzf
+    tms.arg("--just-print");
     let output = tms.assert().success().get_output().stdout.clone();
     let output = String::from_utf8(output)?;
 


### PR DESCRIPTION
Closes #153

This PR unifies the default `tms` command to show both available projects and running tmux sessions in a single, deduplicated list.

Changes:
- Running sessions are now included in the default picker.
- An asterisk (*) is prepended to running sessions to distinguish them.
- The `display_full_path` config option is now respected to show the full path for projects.
- Duplicate entries for the same project/session are now correctly handled.

This code was vibe-coded with the help of the Gemini CLI.