### PR TITLE
feat: add directory creation from picker via customizable hook

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -706,10 +706,12 @@ fn clone_repo_command(args: &CloneRepoCommand, config: Config, tmux: &Tmux) -> R
         return Ok(());
     };
 
-    let (_, repo_name) = args
+    let repo_name = args
         .repository
         .rsplit_once('/')
-        .expect("Repository path contains '/'");
+        .or_else(|| args.repository.rsplit_once(':'))
+        .map(|(_, name)| name)
+        .expect("Repository path contains '/' or ':'");
     let repo_name = repo_name.trim_end_matches(".git");
     path.push(repo_name);
 

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -216,6 +216,13 @@ impl Default for Keymap {
             ),
             (
                 Key {
+                    code: KeyCode::Enter,
+                    modifiers: KeyModifiers::CONTROL,
+                },
+                PickerAction::ForceCreate,
+            ),
+            (
+                Key {
                     code: KeyCode::Delete,
                     modifiers: KeyModifiers::empty(),
                 },
@@ -341,6 +348,8 @@ pub enum PickerAction {
     Cancel,
     #[serde(rename = "confirm")]
     Confirm,
+    #[serde(rename = "force_create")]
+    ForceCreate,
     #[serde(rename = "backspace")]
     Backspace,
     #[serde(rename = "delete")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ fn get_session_list(
     ) {
         // Get active sessions from tmux with timestamps, excluding the currently attached one
         let active_sessions_raw =
-            tmux.list_sessions("'#{?session_attached,,#{session_name},#{session_last_attached}}'");
+            tmux.list_sessions("'#{?session_attached,,#{session_name}#,#{session_last_attached}}'");
 
         // Parse into (name, timestamp) pairs
         let active_sessions: Vec<(&str, i64)> = active_sessions_raw
@@ -173,8 +173,17 @@ NAME="$1"
 FIRST_DIR="$2"
 
 # Detect Git URL (GitHub, GitLab, etc.) and clone it
+# HTTPS: https://github.com/user/repo.git
+# SSH:   git@github.com:user/repo.git
 if [[ "$NAME" =~ ^https?://[^/]+/([^/]+)/([^/]+)(\.git)?$ ]]; then
     REPO_NAME="${BASH_REMATCH[2]%.git}"
+elif [[ "$NAME" =~ ^git@[^:]+:([^/]+)/([^/]+)(\.git)?$ ]]; then
+    REPO_NAME="${BASH_REMATCH[2]%.git}"
+else
+    REPO_NAME=""
+fi
+
+if [[ -n "$REPO_NAME" ]]; then
     TARGET_DIR="$FIRST_DIR/$REPO_NAME"
 
     # Only clone if directory doesn't exist

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,13 @@
-use std::{collections::HashSet, env};
+use std::{collections::HashSet, env, path::PathBuf, process::Command};
 
 use clap::{CommandFactory, Parser};
 use clap_complete::CompleteEnv;
-use error_stack::Report;
+use error_stack::{Report, ResultExt};
 
 use tms::{
     cli::{Cli, SubCommandGiven},
     configs::SessionSortOrderConfig,
-    error::{Result, Suggestion},
+    error::{Result, Suggestion, TmsError},
     session::{create_sessions, SessionContainer},
     tmux::Tmux,
 };
@@ -67,6 +67,12 @@ fn main() -> Result<()> {
     } else {
         return Ok(());
     };
+
+    // Check if user wants to create a new directory
+    if let Some(name) = selected_str.strip_prefix("__TMS_CREATE_NEW__:") {
+        create_new_directory(name, &config, &tmux)?;
+        return Ok(());
+    }
 
     if let Some(session) = sessions.find_session(&selected_str) {
         session.switch_to(&tmux, &config)?;
@@ -142,4 +148,190 @@ fn get_session_list(
         // Default behavior: alphabetically sorted
         (all_sessions, None)
     }
+}
+
+/// Default create hook template embedded in binary
+const DEFAULT_HOOK: &str = r#"#!/usr/bin/env bash
+# tms create hook
+#
+# Called when you type a non-existent name in the tms picker.
+# Example: create-hook "my-app" "/home/user/code" "/home/user/work"
+#
+# Parameters:
+#   $1 = name you typed
+#   $2, $3... = search directories from your config
+#
+# Output (optional):
+#   Print directory name to stdout to override session name
+#   If no output, session name defaults to $1
+#
+# Must: Create a directory that tms can discover, exit 0 on success
+
+set -e
+
+NAME="$1"
+FIRST_DIR="$2"
+
+# Detect Git URL (GitHub, GitLab, etc.) and clone it
+if [[ "$NAME" =~ ^https?://[^/]+/([^/]+)/([^/]+)(\.git)?$ ]]; then
+    REPO_NAME="${BASH_REMATCH[2]%.git}"
+    TARGET_DIR="$FIRST_DIR/$REPO_NAME"
+
+    # Only clone if directory doesn't exist
+    if [[ ! -d "$TARGET_DIR" ]]; then
+        echo "Cloning $REPO_NAME..." >&2
+        git clone "$NAME" "$TARGET_DIR" 2>&1 | sed 's/^/  /' >&2
+        echo "Done!" >&2
+    else
+        echo "Directory $REPO_NAME already exists, opening..." >&2
+    fi
+
+    echo "$REPO_NAME"  # Tell tms the actual directory name
+    exit 0
+fi
+
+# Default: create new directory with git init
+DIR="$FIRST_DIR/$NAME"
+mkdir -p "$DIR"
+cd "$DIR"
+git init -q
+
+# No output = use original name from picker
+
+# Example: customize based on name pattern
+# if [[ "$NAME" == *-rs ]]; then
+#     cargo init --name "${NAME%-rs}"
+#     echo "${NAME%-rs}"  # Return the actual directory name
+# fi
+"#;
+
+/// Ensure the create hook exists at the conventional location
+fn ensure_hook_exists(hook_path: &PathBuf) -> Result<()> {
+    if hook_path.exists() {
+        return Ok(());
+    }
+
+    // Create parent directory if needed
+    if let Some(parent) = hook_path.parent() {
+        std::fs::create_dir_all(parent)
+            .change_context(TmsError::IoError)
+            .attach_printable(format!("Failed to create directory: {}", parent.display()))?;
+    }
+
+    // Write default hook
+    std::fs::write(hook_path, DEFAULT_HOOK)
+        .change_context(TmsError::IoError)
+        .attach_printable(format!("Failed to write hook: {}", hook_path.display()))?;
+
+    // Make executable on Unix
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(hook_path)
+            .change_context(TmsError::IoError)?
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(hook_path, perms)
+            .change_context(TmsError::IoError)
+            .attach_printable("Failed to set hook permissions")?;
+    }
+
+    eprintln!("✓ Created default hook at {}", hook_path.display());
+    eprintln!("  Customize it: nvim {}", hook_path.display());
+
+    Ok(())
+}
+
+/// Check if a file is executable
+#[cfg(unix)]
+fn is_executable(path: &PathBuf) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(path)
+        .map(|m| m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable(_path: &PathBuf) -> bool {
+    true
+}
+
+/// Handle creation of a new directory via the create hook
+fn create_new_directory(name: &str, config: &tms::configs::Config, tmux: &Tmux) -> Result<()> {
+    // Convention: hook is always at ~/.config/tms/create-hook
+    let hook_path = dirs::config_dir()
+        .ok_or(TmsError::ConfigError)
+        .attach_printable("Could not determine config directory")?
+        .join("tms/create-hook");
+
+    // Ensure hook exists (create from template if needed)
+    ensure_hook_exists(&hook_path)?;
+
+    // Check if executable
+    if !is_executable(&hook_path) {
+        return Err(TmsError::ConfigError)
+            .attach_printable(format!("Hook is not executable: {}", hook_path.display()))
+            .attach_printable(format!("Run: chmod +x {}", hook_path.display()));
+    }
+
+    // Get search directories from config
+    let search_dirs = config
+        .search_dirs
+        .as_ref()
+        .ok_or(TmsError::ConfigError)
+        .attach_printable("No search directories configured in config.toml")?;
+
+    let search_paths: Vec<String> = search_dirs
+        .iter()
+        .map(|d| d.path.to_string_lossy().to_string())
+        .collect();
+
+    if search_paths.is_empty() {
+        return Err(TmsError::ConfigError).attach_printable("search_dirs is empty in config.toml");
+    }
+
+    // Execute hook: create-hook "name" "/path1" "/path2" ...
+    // Inherit stderr so user sees progress messages, but capture stdout for directory name
+    let output = Command::new(&hook_path)
+        .arg(name)
+        .args(&search_paths)
+        .stderr(std::process::Stdio::inherit())
+        .output()
+        .change_context(TmsError::IoError)
+        .attach_printable("Failed to execute create hook")?;
+
+    // Check exit status
+    if !output.status.success() {
+        return Err(TmsError::IoError)
+            .attach_printable(format!(
+                "Hook failed with exit code: {}",
+                output.status.code().unwrap_or(-1)
+            ))
+            .attach_printable("Check hook output for details");
+    }
+
+    // Get session name from hook's stdout, or fall back to the typed name
+    let hook_output = String::from_utf8_lossy(&output.stdout);
+    let session_name = hook_output.trim();
+    let session_name = if session_name.is_empty() {
+        name
+    } else {
+        session_name
+    };
+
+    // Re-discover sessions to find the one we just created
+    let sessions = create_sessions(config)?;
+    let session = sessions
+        .find_session(session_name)
+        .ok_or(TmsError::IoError)
+        .attach_printable("Hook did not create a discoverable directory")
+        .attach_printable(format!(
+            "Expected to find a directory matching: {}",
+            session_name
+        ))?;
+
+    // Open it using normal session flow
+    session.switch_to(tmux, config)?;
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,18 +95,28 @@ fn get_session_list(
         config.session_sort_order,
         Some(SessionSortOrderConfig::LastAttached)
     ) {
-        // Get active sessions from tmux with timestamps, excluding the currently attached one
+        // Get all tmux sessions with timestamps and attached status
         let active_sessions_raw =
-            tmux.list_sessions("'#{?session_attached,,#{session_name}#,#{session_last_attached}}'");
+            tmux.list_sessions("'#{session_name},#{session_last_attached},#{session_attached}'");
+
+        // Get the current session name so we can exclude it from the active/bold group
+        let current_session = tmux.display_message("#{session_name}").trim().to_owned();
 
         // Parse into (name, timestamp) pairs
+        // Attached sessions (excluding current) get i64::MAX so they sort first
         let active_sessions: Vec<(&str, i64)> = active_sessions_raw
             .trim()
             .split('\n')
             .filter_map(|line| {
                 let line = line.trim_matches('\'');
-                let (name, timestamp) = line.split_once(',')?;
-                let timestamp = timestamp.parse::<i64>().ok()?;
+                let mut parts = line.splitn(3, ',');
+                let name = parts.next()?.trim();
+                if name.is_empty() || name == current_session {
+                    return None;
+                }
+                let last_attached = parts.next().unwrap_or("").parse::<i64>().unwrap_or(0);
+                let attached = parts.next().unwrap_or("0").parse::<u32>().unwrap_or(0);
+                let timestamp = if attached > 0 { i64::MAX } else { last_attached };
                 Some((name, timestamp))
             })
             .collect();


### PR DESCRIPTION
## Summary

Create directories directly from the picker by typing a name and pressing Enter (or Ctrl+Enter if matches exist). Supports git init and cloning from GitHub/GitLab URLs.

## Changes

* Show dynamic hint for creation options
* Convention-based hook at `~/.config/tms/create-hook` 
* Hook can return custom directory name via stdout
* Default hook: creates directory with `git init`
* Enhanced hook: detects and clones GitHub/GitLab URLs
* Ctrl+Enter to force creation when matches exist
* Auto-creates hook on first use

## Hook Features

**Git URL detection:**
- Type `https://github.com/user/repo` → clones repo → opens session "repo"
- Type `https://gitlab.com/user/project` → clones → opens "project"

**Customizable output:**
- Hook returns directory name via stdout (optional)
- Falls back to typed name if no output
- Enables URL → repo name transformation

**Force creation:**
- No matches: Enter creates
- Matches exist: Ctrl+Enter creates, Enter selects match
- Compact hints: `[^↵: create foo, ↵: open foobar]`

## Testing

All tests pass. Tested with git init, GitHub/GitLab clones, and force creation.