### PR TITLE
refactor(scanning): make repository opening lazy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ dirs = "6.0"
 nucleo = "0.5.0"
 ratatui = { version = "0.29", features = ["serde"] }
 crossterm = "0.28"
+once_cell = "1.20"
 
 [lib]
 name = "tms"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -229,7 +229,7 @@ impl Cli {
                 Ok(SubCommandGiven::Yes)
             }
             Some(CliCommand::Refresh(args)) => {
-                refresh_command(args, config, tmux)?;
+                refresh_command(args, &config, tmux)?;
                 Ok(SubCommandGiven::Yes)
             }
 
@@ -616,7 +616,7 @@ fn rename_subcommand(args: &RenameCommand, tmux: &Tmux) -> Result<()> {
     Ok(())
 }
 
-fn refresh_command(args: &RefreshCommand, config: Config, tmux: &Tmux) -> Result<()> {
+fn refresh_command(args: &RefreshCommand, config: &Config, tmux: &Tmux) -> Result<()> {
     let session_name = args
         .name
         .clone()
@@ -635,9 +635,9 @@ fn refresh_command(args: &RefreshCommand, config: Config, tmux: &Tmux) -> Result
         .map(|line| line.replace('\'', ""))
         .collect();
 
-    if let Ok(repository) = RepoProvider::open(Path::new(&session_path), &config) {
+    if let Ok(repository) = RepoProvider::open(Path::new(&session_path), config) {
         let mut num_worktree_windows = 0;
-        if let Ok(worktrees) = repository.worktrees(&config) {
+        if let Ok(worktrees) = repository.worktrees() {
             for worktree in worktrees.iter() {
                 let worktree_name = worktree.name();
                 if existing_window_names.contains(&worktree_name) {
@@ -741,7 +741,7 @@ fn clone_repo_command(args: &CloneRepoCommand, config: Config, tmux: &Tmux) -> R
     }
 
     tmux.new_session(Some(&session_name), Some(&path.display().to_string()));
-    tmux.set_up_tmux_env(&repo, &session_name, &config)?;
+    tmux.set_up_tmux_env(&repo, &session_name)?;
     if switch {
         tmux.switch_to_session(&session_name);
     }
@@ -787,7 +787,7 @@ fn init_repo_command(args: &InitRepoCommand, config: Config, tmux: &Tmux) -> Res
     }
 
     tmux.new_session(Some(&session_name), Some(&path.display().to_string()));
-    tmux.set_up_tmux_env(&repo, &session_name, &config)?;
+    tmux.set_up_tmux_env(&repo, &session_name)?;
     tmux.switch_to_session(&session_name);
 
     Ok(())

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -249,13 +249,8 @@ impl Tmux {
         self.execute_tmux_command(&["move-window", "-s", source_window, "-t", target_window])
     }
 
-    pub fn set_up_tmux_env(
-        &self,
-        repo: &RepoProvider,
-        repo_name: &str,
-        config: &Config,
-    ) -> Result<()> {
-        let worktrees = repo.worktrees(config).change_context(TmsError::GitError)?;
+    pub fn set_up_tmux_env(&self, repo: &RepoProvider, repo_name: &str) -> Result<()> {
+        let worktrees = repo.worktrees().change_context(TmsError::GitError)?;
         let worktrees = worktrees
             .iter()
             // check only for non prunable worktrees


### PR DESCRIPTION
related to https://github.com/jrmoulton/tmux-sessionizer/issues/173
I already posted this there, but this still needs more testing to ensure there are no functionality regressions :) 

Refactors repository scanning to only actually load the repository contents when it is actually used.
Until now, during the scanning phase repositories were opened via gix::open or jj::Workspace::load only for detection, even if the repository was only shown in the list and never directly interacted with. This could result in large overhead for high search depth or search paths with lots of directories.

This change introduces `LazyRepoProvider`, which only detects the repository type based on configured vcs providers, based on structure:
 - `.git` (dir or file)
 - bare git (`HEAD`, `objects/`, `refs/`)
 - `.jj/repo`

Only when needed, e.g. for submodule detection, or worktree initialization, the repo is actually opened.
For submodules, this is still performed during scanning, so there is no performance gain here, but this option is explicitly opt-in, and in case the user has jj configured over git, the majority of repos will use jj and won't be opened anyway.

#### Benchmarks
(keep in mind I did not see the huge regression mentioned in the thread posted above on my machine)

`target/release/tms` @ 98ced51fd2347d2066acc534d190478345b98559
`/nix/store/wh7i4cc53grar6dmkl5qnkjgwpbnnf6m-tmux-sessionizer-0.5.0/bin/tms` @ 7f016611ba908e6599eee92f0ca15ff4fca9a101

`search_submodules` disabled:
```
hyperfine --warmup 5 --runs 100 'target/release/tms' '/nix/store/wh7i4cc53grar6dmkl5qnkjgwpbnnf6m-tmux-sessionizer-0.5.0/bin/tms' -i
Benchmark 1: target/release/tms
  Time (mean ± σ):      11.5 ms ±   0.7 ms    [User: 6.0 ms, System: 5.8 ms]
  Range (min … max):     9.8 ms …  13.0 ms    100 runs

  Warning: Ignoring non-zero exit code.

Benchmark 2: /nix/store/wh7i4cc53grar6dmkl5qnkjgwpbnnf6m-tmux-sessionizer-0.5.0/bin/tms
  Time (mean ± σ):      22.7 ms ±   0.9 ms    [User: 9.7 ms, System: 13.0 ms]
  Range (min … max):    20.8 ms …  24.7 ms    100 runs

  Warning: Ignoring non-zero exit code.

Summary
  target/release/tms ran
    1.97 ± 0.14 times faster than /nix/store/wh7i4cc53grar6dmkl5qnkjgwpbnnf6m-tmux-sessionizer-0.5.0/bin/tms
```
`search_submodules` enabled (expectedly barely any gain here, since all repos will be opened again)
```
 hyperfine --warmup 5 --runs 100 'target/release/tms' '/nix/store/wh7i4cc53grar6dmkl5qnkjgwpbnnf6m-tmux-sessionizer-0.5.0/bin/tms' -i
Benchmark 1: target/release/tms
  Time (mean ± σ):      40.7 ms ±   1.0 ms    [User: 24.8 ms, System: 15.8 ms]
  Range (min … max):    38.1 ms …  45.4 ms    100 runs

  Warning: Ignoring non-zero exit code.

Benchmark 2: /nix/store/wh7i4cc53grar6dmkl5qnkjgwpbnnf6m-tmux-sessionizer-0.5.0/bin/tms
  Time (mean ± σ):      42.7 ms ±   0.7 ms    [User: 25.6 ms, System: 17.0 ms]
  Range (min … max):    40.4 ms …  44.3 ms    100 runs

  Warning: Ignoring non-zero exit code.

Summary
  target/release/tms ran
    1.05 ± 0.03 times faster than /nix/store/wh7i4cc53grar6dmkl5qnkjgwpbnnf6m-tmux-sessionizer-0.5.0/bin/tms
```
