### PR TITLE
nix: include commit hash in package version

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,9 +44,11 @@
               (import rust-overlay)
             ];
           };
+          packageVersion = (fromTOML (builtins.readFile ./Cargo.toml)).package.version;
           rustToolchain = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
           craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
           commonArgs = with pkgs; {
+            version = "${packageVersion}-${self.shortRev or "dirty"}";
             src = craneLib.cleanCargoSource ./.;
             strictDeps = true;
 


### PR DESCRIPTION
`shortRev` doesn't exist if uncommitted changes exist, which is why the "dirty" fallback exists.
Otherwise this makes it easier to diagnose which version is currently installed for those installing tms via the flake, and makes it easier to report issues/regressions if a specific commit can be identified. `tms --version` output is unaffected.