### PR TITLE
fix: clone-repo Git Error because of the trailing slash

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -708,6 +708,7 @@ fn clone_repo_command(args: &CloneRepoCommand, config: Config, tmux: &Tmux) -> R
 
     let (_, repo_name) = args
         .repository
+        .trim_end_matches('/')
         .rsplit_once('/')
         .expect("Repository path contains '/'");
     let repo_name = repo_name.trim_end_matches(".git");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -710,7 +710,7 @@ fn clone_repo_command(args: &CloneRepoCommand, config: Config, tmux: &Tmux) -> R
         .repository
         .trim_end_matches('/')
         .rsplit_once('/')
-        .expect("Repository path contains '/'");
+        .expect("Repository path contains '/' but does not end with it");
     let repo_name = repo_name.trim_end_matches(".git");
     path.push(repo_name);
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -710,7 +710,7 @@ fn clone_repo_command(args: &CloneRepoCommand, config: Config, tmux: &Tmux) -> R
         .repository
         .trim_end_matches('/')
         .rsplit_once('/')
-        .expect("Repository path contains '/' but does not end with it");
+        .expect("Repository path contains '/'");
     let repo_name = repo_name.trim_end_matches(".git");
     path.push(repo_name);
 


### PR DESCRIPTION
Hi! Sorry for the PR without creating an issue first, just wanted to fix a thing that's been bothering me.

The `clone-repo` behavior is not consistent with the `git clone` command when it comes to the trailing slash.

`git clone` creates a directory with the correct name and starts to clone into it:
```
/tmp> git clone https://github.com/vergeev/tmux-sessionizer/
Cloning into 'tmux-sessionizer'...
```

The `clone-repo` subcommand thinks I want to clone into my project directory:
```
~/D/tmux-sessionizer (main)> target/debug/tms clone-repo https://github.com/jrmoulton/tmux-sessionizer/
fatal: destination path '/Users/vergeev/NetBeansProjects' already exists and is not an empty directory.
Error: Git Error
├╴at src/repos.rs:101:14
╰╴No repo found in "/Users/vergeev/NetBeansProjects/"
```

When I remove the slash it does the right thing:

```
~/D/tmux-sessionizer (main)> target/debug/tms clone-repo https://github.com/jrmoulton/tmux-sessionizer
Cloning into '/Users/vergeev/NetBeansProjects/tmux-sessionizer'...
```

This pull request seems to fix the issue:

``` 
~/D/tmux-sessionizer (main)> target/debug/tms clone-repo https://github.com/jrmoulton/tmux-sessionizer/
Cloning into '/Users/vergeev/NetBeansProjects/tmux-sessionizer'...
```