### PR TITLE
clone: allow specifying target directory path and name

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -159,6 +159,14 @@ pub struct RefreshCommand {
 pub struct CloneRepoCommand {
     /// Git repository to clone
     repository: String,
+    #[arg(long)]
+    /// Directory to create new repository in, if left empty will pick default
+    /// search path or prompt if multiple are configured
+    path: Option<String>,
+    #[arg(long)]
+    /// Name of cloned repository directory, will be picked based on remote url
+    /// if left empty
+    name: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -702,16 +710,26 @@ fn pick_search_path(config: &Config, tmux: &Tmux) -> Result<Option<PathBuf>> {
 }
 
 fn clone_repo_command(args: &CloneRepoCommand, config: Config, tmux: &Tmux) -> Result<()> {
-    let Some(mut path) = pick_search_path(&config, tmux)? else {
+    let Some(mut path) = (if let Some(p) = &args.path {
+        Some(
+            PathBuf::from(p)
+                .canonicalize()
+                .change_context(TmsError::IoError)?,
+        )
+    } else {
+        pick_search_path(&config, tmux)?
+    }) else {
         return Ok(());
     };
 
-    let (_, repo_name) = args
-        .repository
-        .trim_end_matches('/')
-        .rsplit_once('/')
-        .expect("Repository path contains '/'");
-    let repo_name = repo_name.trim_end_matches(".git");
+    let repo_name = args.name.as_deref().unwrap_or_else(|| {
+        let (_, name) = args
+            .repository
+            .trim_end_matches('/')
+            .rsplit_once('/')
+            .expect("Repository path contains '/'");
+        name.trim_end_matches(".git")
+    });
     path.push(repo_name);
 
     let previous_session = tmux.current_session("#{session_name}");


### PR DESCRIPTION
Unlike git, where target is positional and as soon as it is specified, the repository name will no longer be picked automatically from the url, we can split it into two flags, so either one can be overridden manually.

If only name is set, then target will use the usual logic of picking the only valid search dir or falling back to the picker for multiple. If only path is set, then the name will be picked automatically.

This should cover most scenarios for both manual or script usage, however it should be noted that `tms` will open a repo cloned outside of its search paths after cloning it, but afterwards it will no longer show up in its pickers.
This can be fine e.g. for usecases like temporary sessions: `tms clone-repo --path $(mktemp -d) <url>`

closes #185