### PR TITLE
fix: show gitlink worktrees in the picker

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,7 @@
           packageVersion = (fromTOML (builtins.readFile ./Cargo.toml)).package.version;
           rustToolchain = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
           craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+
           commonArgs = with pkgs; {
             version = "${packageVersion}-${self.shortRev or "dirty"}";
             src = craneLib.cleanCargoSource ./.;
@@ -55,7 +56,11 @@
             nativeBuildInputs = [
               installShellFiles
             ];
+          nativeCheckInputs = [
+              git
+            ];
           };
+
           cargoArtifacts = craneLib.buildDepsOnly commonArgs;
           tmux-sessionizer = craneLib.buildPackage (
             commonArgs
@@ -111,7 +116,6 @@
         overlays.default = final: prev: {
           inherit (self.packages.${final.stdenv.hostPlatform.system}) tmux-sessionizer;
         };
-
       };
     };
 }

--- a/src/repos.rs
+++ b/src/repos.rs
@@ -167,10 +167,16 @@ impl LazyRepoProvider {
             .get_or_try_init(|| self.provider.open(&self.path))
     }
 
-    pub fn is_worktree(&self) -> bool {
+    pub fn is_worktree(&self) -> Result<bool> {
         match self.provider {
-            VcsProviders::Git => self.path.join(".git").is_file(),
-            VcsProviders::Jujutsu => self.path.join(".jj/repo").is_file(),
+            VcsProviders::Git => {
+                if !self.path.join(".git").is_file() {
+                    return Ok(false);
+                }
+                let repo = self.resolve()?;
+                Ok(repo.is_worktree())
+            }
+            VcsProviders::Jujutsu => Ok(self.path.join(".jj/repo").is_file()),
         }
     }
 }
@@ -198,7 +204,12 @@ impl RepoProvider {
 
     pub fn is_worktree(&self) -> bool {
         match self {
-            RepoProvider::Git(repo) => !repo.main_repo().is_ok_and(|r| r == **repo),
+            RepoProvider::Git(repo) => {
+                matches!(
+                    repo.kind(),
+                    gix::repository::Kind::WorkTree { is_linked: true }
+                )
+            }
             RepoProvider::Jujutsu(repo) => {
                 let repo_path = repo.repo_path();
                 let workspace_repo_path = repo.workspace_root().join(".jj/repo");
@@ -348,7 +359,7 @@ pub fn find_repos(config: &Config) -> Result<HashMap<String, Vec<Session>>> {
     let mut repos: HashMap<String, Vec<Session>> = HashMap::new();
 
     search_dirs(config, |file, repo| {
-        if repo.is_worktree() {
+        if repo.is_worktree().unwrap_or(true) {
             return Ok(());
         }
 
@@ -483,4 +494,35 @@ pub fn find_submodules<'a>(
         repos.insert_session(name, session);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{fs, process::Command};
+    use tempfile::tempdir;
+
+    #[test]
+    fn gitlink_to_dot_bare_is_not_filtered_as_worktree() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+
+        // 1. Create the bare repository
+        Command::new("git")
+            .args(["init", "--bare"])
+            .arg(root.join(".bare"))
+            .status()
+            .unwrap();
+
+        // 2. Dynamically create the absolute path for the gitdir pointer
+        let bare_path = root.join(".bare");
+        let gitlink_content = format!("gitdir: {}\n", bare_path.display());
+
+        // 3. Write the absolute path to the .git file
+        fs::write(root.join(".git"), gitlink_content).unwrap();
+
+        // 4. Run the assertions
+        let repo = LazyRepoProvider::new(root, &[VcsProviders::Git]).unwrap();
+        assert!(!repo.is_worktree().unwrap());
+    }
 }

--- a/tests/repos.rs
+++ b/tests/repos.rs
@@ -1,0 +1,90 @@
+use std::{fs, path::PathBuf, process::Command};
+
+use tempfile::tempdir;
+use tms::configs::{Config, SearchDirectory, VcsProviders};
+use tms::repos::{find_repos, LazyRepoProvider};
+
+fn config_searching(path: PathBuf, depth: usize) -> Config {
+    Config {
+        search_dirs: Some(vec![SearchDirectory::new(path, depth)]),
+        ..Default::default()
+    }
+}
+
+fn git_commit(repo: &std::path::Path) {
+    Command::new("git")
+        .args(["commit", "--allow-empty", "-m", "init"])
+        .current_dir(repo)
+        .env("GIT_AUTHOR_NAME", "tms-test")
+        .env("GIT_AUTHOR_EMAIL", "tms-test@example.com")
+        .env("GIT_COMMITTER_NAME", "tms-test")
+        .env("GIT_COMMITTER_EMAIL", "tms-test@example.com")
+        .status()
+        .expect("git commit");
+}
+
+#[test]
+fn find_repos_includes_gitlink_project() {
+    let dir = tempdir().unwrap();
+    let search = dir.path().join("search");
+    let project = search.join("my-project");
+    fs::create_dir_all(&project).unwrap();
+    let search = fs::canonicalize(&search).unwrap();
+    Command::new("git")
+        .args(["init", "--bare"])
+        .arg(project.join(".bare"))
+        .status()
+        .unwrap();
+    fs::write(project.join(".git"), "gitdir: .bare\n").unwrap();
+
+    let repos = find_repos(&config_searching(search, 2)).unwrap();
+
+    assert!(
+        repos.contains_key("my-project"),
+        "expected gitlink project in picker results, got: {:?}",
+        repos.keys().collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn find_repos_excludes_linked_worktree() {
+    let dir = tempdir().unwrap();
+    let search = dir.path().join("search");
+    fs::create_dir_all(&search).unwrap();
+    let search = fs::canonicalize(&search).unwrap();
+    let main_repo = search.join("main-repo");
+    let linked = search.join("linked");
+    fs::create_dir_all(&main_repo).unwrap();
+
+    Command::new("git")
+        .args(["init", "-b", "main"])
+        .current_dir(&main_repo)
+        .status()
+        .unwrap();
+    git_commit(&main_repo);
+    Command::new("git")
+        .args(["worktree", "add", "-b", "linked"])
+        .arg(&linked)
+        .current_dir(&main_repo)
+        .status()
+        .unwrap();
+
+    let linked_repo = LazyRepoProvider::new(&linked, &[VcsProviders::Git]).unwrap();
+    assert!(
+        linked_repo.is_worktree().unwrap(),
+        "linked checkout should be classified as a worktree"
+    );
+
+    let repos = find_repos(&config_searching(search, 2)).unwrap();
+
+    assert!(
+        repos.contains_key("main-repo"),
+        "expected main repository in picker results, got: {:?}",
+        repos.keys().collect::<Vec<_>>()
+    );
+    assert!(
+        !repos.contains_key("linked"),
+        "linked worktree should not appear in picker results, got: {:?}",
+        repos.keys().collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
Repositories using a .git file (e.g. `gitdir: .bare`) were skipped because any .git file was treated as a linked worktree. Use gix's `is_linked` flag instead of comparing against `main_repo()`, which incorrectly marked primary gitlink layouts as worktrees. When a .git file is present, resolve the repo before deciding whether to filter it during discovery.

Ref: https://github.com/jrmoulton/tmux-sessionizer/issues/188