### PR TITLE
Add action to publish releases on crates.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Publish to crates.io
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            cargo publish
+          else
+            cargo publish --dry-run
+          fi
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
@jrmoulton this requires the crate owner to permit it on crates.io (as described [here](https://crates.io/docs/trusted-publishing)), and appears to be the recommended setup for this by crates.io.
Not sure how we can actually validate that this works until the next release, but the dry run mode will help somewhat hopefully.

closes #174 