### PR TITLE
fix: bare worktree regression after bump to gix v0.85

### DIFF
--- a/src/repos.rs
+++ b/src/repos.rs
@@ -245,8 +245,12 @@ impl RepoProvider {
 
     pub fn is_worktree(&self) -> bool {
         match self {
+            // TODO: gix 0.85 misclassifies bare-repo worktrees as `Common` rather than `LinkedWorkTree`.
+            // We should revert our workaround once the upstream fix lands.
+            // https://github.com/GitoxideLabs/gitoxide/pull/2699
             RepoProvider::Git(repo) => {
                 matches!(repo.kind(), gix::repository::Kind::LinkedWorkTree)
+                    || repo.workdir().is_some_and(|wd| wd.join(".git").is_file())
             }
             RepoProvider::Jujutsu(repo) => {
                 let repo_path = repo.repo_path();

--- a/src/session.rs
+++ b/src/session.rs
@@ -9,7 +9,7 @@ use crate::{
     configs::{Config, VcsProviders},
     dirty_paths::DirtyUtf8Path,
     error::TmsError,
-    repos::{find_repos, find_submodules, LazyRepoProvider},
+    repos::{find_repos, find_submodules, LazyRepoProvider, RepoProvider},
     tmux::Tmux,
     Result,
 };
@@ -50,15 +50,7 @@ impl Session {
         config: &Config,
     ) -> Result<()> {
         let repo = repo.resolve()?;
-        let path = if repo.is_bare() {
-            repo.path().to_path_buf().to_string()?
-        } else {
-            repo.work_dir()
-                .expect("bare repositories should all have parent directories")
-                .canonicalize()
-                .change_context(TmsError::IoError)?
-                .to_string()?
-        };
+        let path = session_working_dir(repo)?.to_string()?;
         let session_name = self.name.replace('.', "_");
 
         if !tmux.session_exists(&session_name) {
@@ -83,6 +75,13 @@ impl Session {
         tmux.switch_to_session(&session_name);
 
         Ok(())
+    }
+}
+
+fn session_working_dir(repo: &RepoProvider) -> Result<PathBuf> {
+    match repo.work_dir() {
+        Some(work_dir) => work_dir.canonicalize().change_context(TmsError::IoError),
+        None => Ok(repo.path().to_path_buf()),
     }
 }
 
@@ -265,5 +264,28 @@ mod tests {
         assert_eq!(deduplicated[0].name, "projects/proj2/test");
         assert_eq!(deduplicated[1].name, "to/proj2/test");
         assert_eq!(deduplicated[2].name, "to/proj1/test");
+    }
+
+    #[test]
+    fn session_working_dir_of_bare_repo_worktree_is_the_checkout() {
+        use std::process::Command;
+        let dir = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(dir.path()).unwrap();
+        let bare = root.join("project");
+        Command::new("git")
+            .args(["init", "--bare"])
+            .arg(&bare)
+            .status()
+            .unwrap();
+        Command::new("git")
+            .args(["worktree", "add", "master"])
+            .current_dir(&bare)
+            .status()
+            .unwrap();
+
+        let worktree = LazyRepoProvider::new(&bare.join("master"), &[VcsProviders::Git]).unwrap();
+        let dir = session_working_dir(worktree.resolve().unwrap()).unwrap();
+
+        assert_eq!(dir, std::fs::canonicalize(bare.join("master")).unwrap());
     }
 }

--- a/tests/repos.rs
+++ b/tests/repos.rs
@@ -3,6 +3,7 @@ use std::{fs, path::PathBuf, process::Command};
 use tempfile::tempdir;
 use tms::configs::{Config, SearchDirectory, VcsProviders};
 use tms::repos::{find_repos, LazyRepoProvider};
+use tms::session::SessionType;
 
 fn config_searching(path: PathBuf, depth: usize) -> Config {
     Config {
@@ -80,6 +81,52 @@ fn find_repos_includes_worktrees() {
 }
 
 #[test]
+fn find_repos_includes_worktrees_with_relative_paths() {
+    let dir = tempdir().unwrap();
+    let search = dir.path().join("search");
+    let project = search.join("my-project");
+    fs::create_dir_all(&project).unwrap();
+    let search = fs::canonicalize(&search).unwrap();
+    Command::new("git")
+        .args(["init", "--bare"])
+        .arg(&project)
+        .status()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "worktree.useRelativePaths", "true"])
+        .current_dir(&project)
+        .status()
+        .unwrap();
+    Command::new("git")
+        .args(["worktree", "add", "main"])
+        .current_dir(&project)
+        .status()
+        .unwrap();
+    Command::new("git")
+        .args(["worktree", "add", "test"])
+        .current_dir(&project)
+        .status()
+        .unwrap();
+
+    // Ensure `worktree.useRelativePaths` took effect.
+    let gitdir = fs::read_to_string(project.join("worktrees/main/gitdir")).unwrap();
+    assert!(
+        gitdir.trim_start().starts_with(".."),
+        "expected a relative gitdir, got: {gitdir:?}"
+    );
+
+    let mut config = config_searching(search, 2);
+    config.list_worktrees = Some(true);
+
+    let repos = find_repos(&config).unwrap();
+
+    assert!(repos.contains_key("my-project"));
+    assert!(repos.contains_key("my-project#main"));
+    assert!(repos.contains_key("my-project#test"));
+    assert_eq!(repos.len(), 3);
+}
+
+#[test]
 fn find_repos_excludes_linked_worktree() {
     let dir = tempdir().unwrap();
     let search = dir.path().join("search");
@@ -119,5 +166,79 @@ fn find_repos_excludes_linked_worktree() {
         !repos.contains_key("linked"),
         "linked worktree should not appear in picker results, got: {:?}",
         repos.keys().collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn find_repos_worktree_entry_is_a_worktree() {
+    let dir = tempdir().unwrap();
+    let search = dir.path().join("search");
+    let project = search.join("my-project");
+    fs::create_dir_all(&project).unwrap();
+    let search = fs::canonicalize(&search).unwrap();
+    Command::new("git")
+        .args(["init", "--bare"])
+        .arg(&project)
+        .status()
+        .unwrap();
+    Command::new("git")
+        .args(["worktree", "add", "main"])
+        .current_dir(&project)
+        .status()
+        .unwrap();
+    Command::new("git")
+        .args(["worktree", "add", "test"])
+        .current_dir(&project)
+        .status()
+        .unwrap();
+    let mut config = config_searching(search, 2);
+    config.list_worktrees = Some(true);
+
+    let repos = find_repos(&config).unwrap();
+
+    let main_entry = repos
+        .get("my-project#main")
+        .expect("expected a my-project#main entry");
+    let SessionType::Git(main_worktree) = &main_entry[0].session_type else {
+        panic!("my-project#main should be a Git session");
+    };
+    assert!(
+        main_worktree.is_worktree().unwrap(),
+        "opening my-project#main should open only the `main` worktree, not fan out into siblings"
+    );
+
+    let repo_entry = repos
+        .get("my-project")
+        .expect("expected a my-project entry");
+    let SessionType::Git(whole_repo) = &repo_entry[0].session_type else {
+        panic!("my-project should be a Git session");
+    };
+    assert!(
+        !whole_repo.is_worktree().unwrap(),
+        "the bare repo itself is not a worktree; opening it is what fans out into per-worktree windows"
+    );
+}
+
+#[test]
+fn bare_repo_worktree_is_classified_as_worktree() {
+    let dir = tempdir().unwrap();
+    let root = fs::canonicalize(dir.path()).unwrap();
+    let bare = root.join("project");
+    Command::new("git")
+        .args(["init", "--bare"])
+        .arg(&bare)
+        .status()
+        .unwrap();
+    Command::new("git")
+        .args(["worktree", "add", "master"])
+        .current_dir(&bare)
+        .status()
+        .unwrap();
+
+    let worktree = LazyRepoProvider::new(&bare.join("master"), &[VcsProviders::Git]).unwrap();
+
+    assert!(
+        worktree.is_worktree().unwrap(),
+        "a worktree of a bare repo should be classified as a worktree"
     );
 }


### PR DESCRIPTION
## Regressions

#192 introduced two regressions for bare worktrees:

1. Opening a worktree as a session now opens all worktrees as windows.
2. The session working dir is `$GIT_DIR/worktrees/<name>` instead of the path to the worktree.

## Cause

gix 0.85 has two API changes:
1. `Repository::kind()` returns [Kind::Common](https://docs.rs/gix/0.85.0/gix/repository/enum.Kind.html) for bare worktrees instead of Kind::LinkedWorkTree.
2. `is_bare()` returns `true` despite the worktree having a checkout.

I'm pretty sure (1) is a gix bug. I [made a PR to gix](https://github.com/GitoxideLabs/gitoxide/pull/2699) which should hopefully fix things! When that happens, we can revert the change to `is_worktree()`. Seems like (2) is an intentional API change.

## Steps to Reproduce

```bash
mkdir -p /tmp/bug-demo && cd /tmp/bug-demo
git init --bare project
cd project
git worktree add master
git worktree add feature-a

cd ..
cat >config.toml <<EOF
list_worktrees = true

[[search_dirs]]
path = "/tmp/bug-demo"
depth = 1
EOF

TMS_CONFIG_FILE=/tmp/bug-demo/config.toml tms open-session 'project#master'
tmux list-windows -t 'project#master'
tmux display-message -t 'project#master' -p '#{session_path}'
```

###  Before

```
$ tmux list-windows -t 'project#master'
1: master- (1 panes) [181x50] [layout 2c0e,181x50,0,0,135] @134
2: feature-a* (1 panes) [181x50] [layout 2c0f,181x50,0,0,136] @135 (active)

$ tmux display-message -t 'project#master' -p '#{session_path}'
/private/tmp/bug-demo/project/worktrees/master
```

### After

```
$ tmux list-windows -t 'project#master'
1: zsh* (1 panes) [181x50] [layout ac12,181x50,0,0,168] @166 (active)

$ tmux display-message -t 'project#master' -p '#{session_path}'
/private/tmp/bug-demo/project/master
```