### PR TITLE
Stop counting control-mode clients as people using a session

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -313,22 +313,13 @@ fn start_command(config: Config, tmux: &Tmux) -> Result<()> {
 }
 
 fn switch_command(config: Config, tmux: &Tmux) -> Result<()> {
-    let sessions = tmux
-        .list_sessions("'#{?session_attached,,#{session_name}#,#{session_last_attached}}'")
-        .replace('\'', "")
-        .replace("\n\n", "\n");
-
-    let mut sessions: Vec<(&str, &str)> = sessions
-        .trim()
-        .split('\n')
-        .filter_map(|s| s.split_once(','))
-        .collect();
+    let mut sessions = tmux.unattached_sessions();
 
     if let Some(SessionSortOrderConfig::LastAttached) = config.session_sort_order {
-        sessions.sort_by(|a, b| b.1.cmp(a.1));
+        sessions.sort_by(|a, b| b.1.cmp(&a.1));
     }
 
-    let mut sessions: Vec<String> = sessions.into_iter().map(|s| s.0.to_string()).collect();
+    let mut sessions: Vec<String> = sessions.into_iter().map(|s| s.0).collect();
     if let Some(true) = config.switch_filter_unknown {
         let configured = create_sessions(&config)?;
 
@@ -509,19 +500,10 @@ fn kill_subcommand(config: Config, tmux: &Tmux) -> Result<()> {
     let mut current_session = tmux.display_message("'#S'");
     current_session.retain(|x| x != '\'' && x != '\n');
 
-    let sessions = tmux
-        .list_sessions("'#{?session_attached,,#{session_name}#,#{session_last_attached}}'")
-        .replace('\'', "")
-        .replace("\n\n", "\n");
-
-    let mut sessions: Vec<(&str, &str)> = sessions
-        .trim()
-        .split('\n')
-        .filter_map(|s| s.split_once(','))
-        .collect();
+    let mut sessions = tmux.unattached_sessions();
 
     if let Some(SessionSortOrderConfig::LastAttached) = config.session_sort_order {
-        sessions.sort_by(|a, b| b.1.cmp(a.1));
+        sessions.sort_by(|a, b| b.1.cmp(&a.1));
     }
 
     let to_session = if config.default_session.is_some()
@@ -532,7 +514,7 @@ fn kill_subcommand(config: Config, tmux: &Tmux) -> Result<()> {
     {
         config.default_session.as_deref()
     } else {
-        sessions.first().map(|s| s.0)
+        sessions.first().map(|s| s.0.as_str())
     };
     if let Some(to_session) = to_session {
         tmux.switch_client(to_session);

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,19 +89,14 @@ fn get_session_list(
         config.session_sort_order,
         Some(SessionSortOrderConfig::LastAttached)
     ) {
-        // Get active sessions from tmux with timestamps, excluding the currently attached one
-        let active_sessions_raw =
-            tmux.list_sessions("'#{?session_attached,,#{session_name}#,#{session_last_attached}}'");
+        // Get active sessions from tmux with timestamps, excluding any a client is attached to
+        let unattached = tmux.unattached_sessions();
 
         // Parse into (name, timestamp) pairs
-        let active_sessions: Vec<(&str, i64)> = active_sessions_raw
-            .trim()
-            .split('\n')
-            .filter_map(|line| {
-                let line = line.trim_matches('\'');
-                let (name, timestamp) = line.split_once(',')?;
-                let timestamp = timestamp.parse::<i64>().ok()?;
-                Some((name, timestamp))
+        let active_sessions: Vec<(&str, i64)> = unattached
+            .iter()
+            .filter_map(|(name, last_attached)| {
+                Some((name.as_str(), last_attached.parse::<i64>().ok()?))
             })
             .collect();
 

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -76,6 +76,36 @@ impl Tmux {
         Tmux::stdout_to_string(output)
     }
 
+    /// Sessions nobody is looking at, as `(name, last_attached)` pairs, most recent first when the
+    /// caller sorts on the second field.
+    ///
+    /// `#{session_attached}` counts every client, control-mode ones included. A tool that keeps a
+    /// `tmux -C attach-session` open per session — tmux-agents' daemon does, because tmux's
+    /// `%output` and `refresh-client -B` subscriptions are session-scoped — therefore makes every
+    /// session look attached, and a picker filtered on that comes up empty. Only a client someone
+    /// is actually looking at should hide a session, so the attached set comes from `list-clients`
+    /// with the control-mode ones dropped.
+    pub fn unattached_sessions(&self) -> Vec<(String, String)> {
+        let watched: Vec<String> = self
+            .list_clients("'#{?client_control_mode,,#{client_session}}'")
+            .lines()
+            .map(|line| line.trim().trim_matches('\'').to_string())
+            .filter(|session| !session.is_empty())
+            .collect();
+
+        self.list_sessions("'#{session_name},#{session_last_attached}'")
+            .lines()
+            .filter_map(|line| line.trim().trim_matches('\'').split_once(','))
+            .filter(|(name, _)| !watched.iter().any(|w| w == name))
+            .map(|(name, last_attached)| (name.to_string(), last_attached.to_string()))
+            .collect()
+    }
+
+    pub fn list_clients(&self, format: &str) -> String {
+        let output = self.execute_tmux_command(&["list-clients", "-F", format]);
+        Tmux::stdout_to_string(output)
+    }
+
     pub fn current_session(&self, format: &str) -> String {
         let output = self.execute_tmux_command(&[
             "list-sessions",

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -106,15 +106,16 @@ impl Tmux {
         Tmux::stdout_to_string(output)
     }
 
+    /// The session the invoking client is in.
+    ///
+    /// `display-message` is the only way to ask this: it is client-scoped, so it answers for the
+    /// client that ran `tms`. The previous `list-sessions -f '#{session_attached}'` was
+    /// server-scoped and returned EVERY session with a client on it — one line per attached
+    /// session, not the current one. With a single client that read the same most of the time,
+    /// which is why it went unnoticed; with a second client attached anywhere (a person's, or a
+    /// control-mode monitor's) it returns several sessions.
     pub fn current_session(&self, format: &str) -> String {
-        let output = self.execute_tmux_command(&[
-            "list-sessions",
-            "-F",
-            format,
-            "-f",
-            "#{session_attached}",
-        ]);
-        Tmux::stdout_to_string(output)
+        self.display_message(format)
     }
 
     pub fn kill_session(&self, session: &str) -> process::Output {


### PR DESCRIPTION
Two related fixes. Both come from asking tmux the wrong question about who is using a session; the first is the one that made me go looking.

## 1. Control-mode clients hide sessions from the pickers

`tms switch`, `tms kill` and the `LastAttached` sort all pick sessions with this format:

```
'#{?session_attached,,#{session_name}#,#{session_last_attached}}'
```

`#{session_attached}` counts *every* client attached to a session, including control-mode ones (`tmux -C attach-session`). A control-mode client is a program watching a session, not a person looking at it — so any tool that keeps one open per session makes every session look attached, and these pickers come up empty.

I ran into it with [tmux-agents](https://github.com/pperanich/tmux-agents), whose daemon holds a `tmux -C` client per session (tmux's `%output` and `refresh-client -B` subscriptions are session-scoped, so one client per session is the only way to get push events server-wide). It is not specific to that tool — any control-mode monitor does it.

Six live sessions, and an empty picker:

```
$ tmux list-clients -F '#{client_session} control=#{client_control_mode}'
dotfiles control=1
0 control=1
tmux-agents control=1
vault control=1
oss/feed-me control=1
personal-site control=1
tmux-agents control=0      # the only client I am actually looking at

$ tmux list-sessions -F "'#{?session_attached,,#{session_name}#,#{session_last_attached}}'"
''
''
''
''
''
''
```

**Fix:** take the attached set from `list-clients` with the control-mode clients dropped, so only a client someone is actually looking at hides a session. The three call sites each carried a copy of the same parse, so they now share one `Tmux::unattached_sessions()` returning `(name, last_attached)` pairs.

Nothing changes for anyone without a control-mode client: a session with an ordinary client attached is still filtered out, and the current session still never appears in `tms switch`.

## 2. `current_session` returns every attached session, not the current one

Found while fixing the above. `current_session` ran:

```rust
list-sessions -F <format> -f '#{session_attached}'
```

which is server-scoped — it returns every session that has a client, one per line. On the same machine as above it returns seven sessions where the answer is `tmux-agents`.

With exactly one client it reads the same most of the time, which is presumably why it went unnoticed. Its caller is `tms clone`, which compares the value before and after the clone to decide whether the user is still where they started (`clone_repo_switch = "foreground"`). Comparing two lists of every attached session does not answer that question: with a control-mode client per session the list is *all* sessions and never changes, so moving between sessions during a clone goes undetected and `foreground` silently behaves like `always`.

**Fix:** delegate to `display-message`, which is client-scoped and already used elsewhere in this file for exactly this question. Only edge case: run outside tmux it yields an empty string, but both sides of the comparison are empty, so it compares equal and switches — same as today.

This one only affects people who set `clone_repo_switch = "foreground"`, since `always` is the default. Happy to split it into its own PR if you would rather take the first fix alone.

## Verification

`tms switch` on the same server, before and after: empty picker → `5/5`, every session except the one my terminal is attached to.

No test added: the existing suite does not spawn a tmux server, and this needs a live one with a control-mode client attached. Glad to add a harness if you want one. By hand:

```
tmux new-session -d -s probe
tmux -C attach-session -t probe &   # a control-mode client, as a monitor would hold
tms switch                          # before: `probe` is missing. after: it is listed.
```